### PR TITLE
Fix campaign dates use in public(), so that empty version end date no longer affects versions with campaigns

### DIFF
--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -30,20 +30,21 @@ class BaseVersionQuerySet(models.QuerySet):
     def _public_qs(self, when):
         return self.filter(
             (
-                Q(start__lte=when) |
-                Q(campaigns__start__lte=when)
-            ) & (
-                Q(end__gte=when) |
-                Q(end__isnull=True) |
-                (
-                    Q(campaigns__isnull=False) &
-                    (
-                        Q(campaigns__end__gte=when) |
-                        Q(campaigns__end__isnull=True)
-                    )
+                Q(start__lte=when) & (
+                    Q(end__isnull=True) |
+                    Q(end__gte=when)
                 )
-            ) & Q(is_active=True)
-        ).order_by('-created')
+            ) | (
+                Q(
+                    campaigns__isnull=False,
+                    campaigns__start__lte=when,
+
+                ) & (
+                    Q(campaigns__end__gte=when) |
+                    Q(campaigns__end__isnull=True)
+                )
+            )
+        ).filter(is_active=True).order_by('-created')
 
     def public(self, when=None):
         """Returns `Version` considered as public for a given date

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,7 +104,7 @@ class ModelsVersioningTestCase(CMSTestCase):
         )
         self.assertEqual(qs.count(), 1)
 
-    def test_public(self):
+    def test_public_dates(self):
         now = timezone.now()
 
         version2 = self.initial_version.copy()
@@ -125,6 +125,36 @@ class ModelsVersioningTestCase(CMSTestCase):
         self.assertEqual(_public(), version2)
         self.assertEqual(_public(now + timedelta(days=5)), version3)
         self.assertEqual(_public(now + timedelta(days=13)), version2)
+
+    def test_public_campaigns(self):
+        now = timezone.now()
+        version = self.initial_version
+        campaign1 = Campaign.objects.create(
+            name='Summer',
+            start=now + timedelta(days=7),
+            end=now + timedelta(days=14),
+        )
+        campaign2 = Campaign.objects.create(
+            name='Winter',
+            start=now + timedelta(days=28),
+            end=now + timedelta(days=35),
+        )
+        version.start = None
+        version.end = None
+        version.save()
+        version.campaigns.set([campaign1, campaign2])
+
+        def _public(when=None):
+            return PollVersion.objects.for_grouper(
+                version.content.poll,
+                Q(content__language='en'),
+            ).public(when)
+
+        self.assertIsNone(_public())
+        self.assertEqual(_public(now + timedelta(days=8)), version)
+        self.assertIsNone(_public(now + timedelta(days=20)))
+        self.assertEqual(_public(now + timedelta(days=30)), version)
+        self.assertIsNone(_public(now + timedelta(days=40)))
 
     def test_runtime_error_raised_without_grouper_field_override(self):
         version_without_grouper = VersionWithoutGrouperField()


### PR DESCRIPTION
Add test for campaign dates use in public()