### PR TITLE
Revert dependency on CMS version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import djangocms_versioning
 
 INSTALL_REQUIREMENTS = [
     'Django>=1.11,<2.1',
-    'django-cms>3.6',
+    'django-cms>3.5',
     'django-fsm>=2.6,<2.7'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import djangocms_versioning
 
 INSTALL_REQUIREMENTS = [
     'Django>=1.11,<2.1',
-    'django-cms>3.5',
+    'django-cms>=3.5',
     'django-fsm>=2.6,<2.7'
 ]
 


### PR DESCRIPTION
Versioning requires 4.0, but it's not released yet. tox installs correct version anyway.