### PR TITLE
Enabling POST only for required admin views

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -5,7 +5,7 @@ from django.contrib.admin.options import IncorrectLookupParameters, TO_FIELD_VAR
 from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.contenttypes.models import ContentType
-from django.http import Http404
+from django.http import Http404, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
@@ -213,14 +213,9 @@ class VersionAdmin(admin.ModelAdmin):
         """Archives the specified version and redirects back to the
         version changelist
         """
-        # FIXME: We should be using POST only for this, but some frontend
-        # issues need to be solved first. The code below just needs to
-        # be uncommented and a test is also already written (but currently
-        # being skipped) to handle the POST-only approach
-
         # This view always changes data so only POST requests should work
-        # if request.method != 'POST':
-        #     raise Http404
+        if request.method != 'POST':
+            return HttpResponseNotAllowed(['POST'])
 
         # Check version exists
         version = self.get_object(request, unquote(object_id))
@@ -245,14 +240,9 @@ class VersionAdmin(admin.ModelAdmin):
         """Publishes the specified version and redirects back to the
         version changelist
         """
-        # FIXME: We should be using POST only for this, but some frontend
-        # issues need to be solved first. The code below just needs to
-        # be uncommented and a test is also already written (but currently
-        # being skipped) to handle the POST-only approach
-
         # This view always changes data so only POST requests should work
-        # if request.method != 'POST':
-        #     raise Http404
+        if request.method != 'POST':
+            return HttpResponseNotAllowed(['POST'])
 
         # Check version exists
         version = self.get_object(request, unquote(object_id))
@@ -277,14 +267,9 @@ class VersionAdmin(admin.ModelAdmin):
         """Unpublishes the specified version and redirects back to the
         version changelist
         """
-        # FIXME: We should be using POST only for this, but some frontend
-        # issues need to be solved first. The code below just needs to
-        # be uncommented and a test is also already written (but currently
-        # being skipped) to handle the POST-only approach
-
         # This view always changes data so only POST requests should work
-        # if request.method != 'POST':
-        #     raise Http404
+        if request.method != 'POST':
+            return HttpResponseNotAllowed(['POST'])
 
         # Check version exists
         version = self.get_object(request, unquote(object_id))
@@ -309,14 +294,9 @@ class VersionAdmin(admin.ModelAdmin):
         """Redirects to the admin change view and creates a draft version
         if no draft exists yet.
         """
-        # FIXME: We should be using POST only for this, but some frontend
-        # issues need to be solved first. The code below just needs to
-        # be uncommented and a test is also already written (but currently
-        # being skipped) to handle the POST-only approach
-
         # This view always changes data so only POST requests should work
-        # if request.method != 'POST':
-        #     raise Http404
+        if request.method != 'POST':
+            return HttpResponseNotAllowed(['POST'])
 
         version = self.get_object(request, unquote(object_id))
         if version is None:

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -215,7 +215,7 @@ class VersionAdmin(admin.ModelAdmin):
         """
         # This view always changes data so only POST requests should work
         if request.method != 'POST':
-            return HttpResponseNotAllowed(['POST'])
+            return HttpResponseNotAllowed(['POST'], 'This view only supports POST method.')
 
         # Check version exists
         version = self.get_object(request, unquote(object_id))
@@ -242,7 +242,7 @@ class VersionAdmin(admin.ModelAdmin):
         """
         # This view always changes data so only POST requests should work
         if request.method != 'POST':
-            return HttpResponseNotAllowed(['POST'])
+            return HttpResponseNotAllowed(['POST'], 'This view only supports POST method.')
 
         # Check version exists
         version = self.get_object(request, unquote(object_id))
@@ -269,7 +269,7 @@ class VersionAdmin(admin.ModelAdmin):
         """
         # This view always changes data so only POST requests should work
         if request.method != 'POST':
-            return HttpResponseNotAllowed(['POST'])
+            return HttpResponseNotAllowed(['POST'], 'This view only supports POST method.')
 
         # Check version exists
         version = self.get_object(request, unquote(object_id))
@@ -296,7 +296,7 @@ class VersionAdmin(admin.ModelAdmin):
         """
         # This view always changes data so only POST requests should work
         if request.method != 'POST':
-            return HttpResponseNotAllowed(['POST'])
+            return HttpResponseNotAllowed(['POST'], 'This view only supports POST method.')
 
         version = self.get_object(request, unquote(object_id))
         if version is None:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,6 +1,5 @@
 import datetime
 import warnings
-from unittest import skip
 from unittest.mock import Mock, patch
 
 from django.contrib import admin
@@ -704,7 +703,6 @@ class ArchiveViewTestCase(CMSTestCase):
             mocked_messages.call_args[0][2],
             'poll content version with ID "89" doesn\'t exist. Perhaps it was deleted?')
 
-    @skip("Awaiting frontend work before this can be fixed")
     def test_archive_view_cant_be_accessed_by_get_request(self):
         poll_version = factories.PollVersionFactory(state=constants.DRAFT)
         url = self.get_admin_url(
@@ -713,10 +711,10 @@ class ArchiveViewTestCase(CMSTestCase):
         with self.login_user_context(self.get_staff_user_with_no_permissions()):
             response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 405)
         # status hasn't changed
         poll_version_ = Version.objects.get(pk=poll_version.pk)
-        self.assertEqual(poll_version_.state, constants.ARCHIVED)
+        self.assertEqual(poll_version_.state, constants.DRAFT)
         # no status change has been tracked
         self.assertEqual(StateTracking.objects.all().count(), 0)
 
@@ -831,7 +829,6 @@ class PublishViewTestCase(CMSTestCase):
             mocked_messages.call_args[0][2],
             'poll content version with ID "89" doesn\'t exist. Perhaps it was deleted?')
 
-    @skip("Awaiting frontend work before this can be fixed")
     def test_publish_view_cant_be_accessed_by_get_request(self):
         poll_version = factories.PollVersionFactory(state=constants.DRAFT)
         url = self.get_admin_url(
@@ -840,10 +837,10 @@ class PublishViewTestCase(CMSTestCase):
         with self.login_user_context(self.get_staff_user_with_no_permissions()):
             response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 405)
         # status hasn't changed
         poll_version_ = Version.objects.get(pk=poll_version.pk)
-        self.assertEqual(poll_version_.state, constants.PUBLISHED)
+        self.assertEqual(poll_version_.state, constants.DRAFT)
         # no status change has been tracked
         self.assertEqual(StateTracking.objects.all().count(), 0)
 
@@ -955,7 +952,6 @@ class UnpublishViewTestCase(CMSTestCase):
             mocked_messages.call_args[0][2],
             'poll content version with ID "89" doesn\'t exist. Perhaps it was deleted?')
 
-    @skip("Awaiting frontend work before this can be fixed")
     def test_unpublish_view_cant_be_accessed_by_get_request(self):
         poll_version = factories.PollVersionFactory(state=constants.PUBLISHED)
         url = self.get_admin_url(
@@ -964,7 +960,7 @@ class UnpublishViewTestCase(CMSTestCase):
         with self.login_user_context(self.get_staff_user_with_no_permissions()):
             response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 405)
         # status hasn't changed
         poll_version_ = Version.objects.get(pk=poll_version.pk)
         self.assertEqual(poll_version_.state, constants.PUBLISHED)
@@ -1142,7 +1138,6 @@ class EditRedirectTestCase(CMSTestCase):
             mocked_messages.call_args[0][2],
             'poll content version with ID "89" doesn\'t exist. Perhaps it was deleted?')
 
-    @skip("Awaiting frontend work before this can be fixed")
     def test_edit_redirect_view_cant_be_accessed_by_get_request(self):
         poll_version = factories.PollVersionFactory(state=constants.PUBLISHED)
         url = self.get_admin_url(
@@ -1151,7 +1146,7 @@ class EditRedirectTestCase(CMSTestCase):
         with self.login_user_context(self.get_staff_user_with_no_permissions()):
             response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 405)
         # no draft was created
         self.assertFalse(Version.objects.filter(state=constants.DRAFT).exists())
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -712,6 +712,7 @@ class ArchiveViewTestCase(CMSTestCase):
             response = self.client.get(url)
 
         self.assertEqual(response.status_code, 405)
+        self.assertEqual(response._headers.get('allow'), ('Allow', 'POST'))
         # status hasn't changed
         poll_version_ = Version.objects.get(pk=poll_version.pk)
         self.assertEqual(poll_version_.state, constants.DRAFT)
@@ -838,6 +839,7 @@ class PublishViewTestCase(CMSTestCase):
             response = self.client.get(url)
 
         self.assertEqual(response.status_code, 405)
+        self.assertEqual(response._headers.get('allow'), ('Allow', 'POST'))
         # status hasn't changed
         poll_version_ = Version.objects.get(pk=poll_version.pk)
         self.assertEqual(poll_version_.state, constants.DRAFT)
@@ -961,6 +963,7 @@ class UnpublishViewTestCase(CMSTestCase):
             response = self.client.get(url)
 
         self.assertEqual(response.status_code, 405)
+        self.assertEqual(response._headers.get('allow'), ('Allow', 'POST'))
         # status hasn't changed
         poll_version_ = Version.objects.get(pk=poll_version.pk)
         self.assertEqual(poll_version_.state, constants.PUBLISHED)
@@ -1147,6 +1150,7 @@ class EditRedirectTestCase(CMSTestCase):
             response = self.client.get(url)
 
         self.assertEqual(response.status_code, 405)
+        self.assertEqual(response._headers.get('allow'), ('Allow', 'POST'))
         # no draft was created
         self.assertFalse(Version.objects.filter(state=constants.DRAFT).exists())
 


### PR DESCRIPTION
This PR includes enabling admin views (publish, unpublish, archive, edit_redirect) only accept POST method.