### PR TITLE
FIL-591 make the links in the sideframe open in top level window

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -154,7 +154,7 @@ class VersionAdmin(admin.ModelAdmin):
             ), args=[content.pk])
 
         return format_html(
-            '<a href="{url}">{label}</a>',
+            '<a target="_top" class="js-versioning-close-sideframe" href="{url}">{label}</a>',
             url=url,
             label=content,
         )

--- a/djangocms_versioning/static/djangocms_versioning/js/actions.js
+++ b/djangocms_versioning/static/djangocms_versioning/js/actions.js
@@ -1,4 +1,8 @@
 (function($) {
+    if (!$) {
+        return;
+    }
+
     $(function() {
         // it is not possible to put a form inside a form, so
         // the versioning actions have to create their own form on click
@@ -18,5 +22,12 @@
 
                 fakeForm.appendTo(document.body).submit();
             });
+
+        $('.js-versioning-close-sideframe').on('click', function () {
+            try {
+                window.top.CMS.$('.cms-sideframe-close').trigger('click.cms.sideframe');
+            } catch (e) {}
+        });
     });
-})((typeof django !== 'undefined' && django.jQuery) || (typeof CMS !== 'undefined' && CMS.$));
+
+})((typeof django !== 'undefined' && django.jQuery) || (typeof CMS !== 'undefined' && CMS.$) || false);


### PR DESCRIPTION
Works only with https://github.com/divio/django-cms/pull/6515,
cause closing sideframe forces resolve to happen and that redirects to root and that's not what we wanted