### PR TITLE
Grouper form choices fallback

### DIFF
--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -3,6 +3,7 @@ import collections
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
+from django.utils.translation import ugettext_lazy as _
 
 from cms.app_base import CMSAppConfig, CMSAppExtension
 from cms.models import PageContent, Placeholder
@@ -138,7 +139,10 @@ def label_from_instance(obj, language):
     """
     Override the label for each grouper select option
     """
-    return "{title} ({path})".format(title=obj.get_title(language), path=obj.get_path(language))
+    title = obj.get_title(language) or _("No available title")
+    path = obj.get_path(language)
+    path = "/{}/".format(path) if path else _("Unpublished")
+    return "{title} ({path})".format(title=title, path=path)
 
 
 def on_page_content_publish(version):

--- a/djangocms_versioning/compat.py
+++ b/djangocms_versioning/compat.py
@@ -1,0 +1,18 @@
+try:
+    from django.db.models.functions import StrIndex
+except ImportError:
+    # Backport from Django 2.0
+    from django.db.models import Func, fields
+
+    class StrIndex(Func):
+        """
+        Return a positive integer corresponding to the 1-indexed position of the
+        first occurrence of a substring inside another string, or 0 if the
+        substring is not found.
+        """
+        function = 'INSTR'
+        arity = 2
+        output_field = fields.IntegerField()
+
+        def as_postgresql(self, compiler, connection, **extra_context):
+            return super().as_sql(compiler, connection, function='STRPOS', **extra_context)

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -5,7 +5,6 @@ from django.contrib import admin
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 
-from .admin import VersionAdmin, VersioningAdminMixin
 from .managers import PublishedContentManagerMixin
 from .models import Version
 
@@ -17,6 +16,7 @@ def versioning_admin_factory(admin_class):
     :param admin_class: Existing admin class
     :return: A subclass of `VersioningAdminMixin` and `admin_class`
     """
+    from .admin import VersioningAdminMixin
     return type('Versioned' + admin_class.__name__, (VersioningAdminMixin, admin_class), {})
 
 
@@ -30,6 +30,7 @@ def _replace_admin_for_model(modeladmin, admin_site):
     :param model: ModelAdmin instance
     :param admin_site: AdminSite instance
     """
+    from .admin import VersioningAdminMixin
     if isinstance(modeladmin, VersioningAdminMixin):
         return
     new_admin_class = versioning_admin_factory(modeladmin.__class__)
@@ -62,6 +63,8 @@ def register_versionadmin_proxy(versionable, admin_site=None):
     :param versionable: VersionableItem instance
     :param admin_site: AdminSite instance
     """
+    from .admin import VersionAdmin
+
     if admin_site is None:
         admin_site = admin.site
 

--- a/djangocms_versioning/versionables.py
+++ b/djangocms_versioning/versionables.py
@@ -1,0 +1,12 @@
+from django.apps import apps
+from django.db.models.base import Model
+
+
+def _cms_extension():
+    return apps.get_app_config('djangocms_versioning').cms_extension
+
+
+def for_content(model_or_obj):
+    if isinstance(model_or_obj, Model):
+        model_or_obj = model_or_obj.__class__
+    return _cms_extension().versionables_by_content[model_or_obj]

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -51,9 +51,8 @@ class GrouperFormTestCase(CMSTestCase):
         """
         version = factories.PageVersionFactory()
         form_class = grouper_form_factory(PageContent, version.content.language)
-        label = "{title} ({path})".format(
+        label = "{title} (Unpublished)".format(
             title=version.content.page.get_title(version.content.language),
-            path=version.content.page.get_path(version.content.language),
         )
 
         self.assertIn(


### PR DESCRIPTION
Grouper form choices will now fallback to less important content objects using the following state order: published -> draft -> archived/unpublished