### PR TITLE
Add public functions for retrieving version list URLs

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -24,12 +24,10 @@ from cms.utils.conf import get_cms_setting
 from cms.utils.helpers import is_editable_model
 from cms.utils.urlutils import add_url_parameters
 
-from .constants import DRAFT, PUBLISHED
+from .constants import DRAFT, GROUPER_PARAM, PUBLISHED
 from .forms import grouper_form_factory
+from .helpers import version_list_url
 from .models import Version
-
-
-GROUPER_PARAM = 'grouper'
 
 
 class VersioningAdminMixin:
@@ -310,11 +308,7 @@ class VersionAdmin(admin.ModelAdmin):
         # Display message
         messages.success(request, _("Version archived"))
         # Redirect
-        url = reverse('admin:{app}_{model}_changelist'.format(
-            app=self.model._meta.app_label,
-            model=self.model._meta.model_name,
-        )) + '?grouper=' + str(version.grouper.pk)
-        return redirect(url)
+        return redirect(version_list_url(version.content))
 
     def publish_view(self, request, object_id):
         """Publishes the specified version and redirects back to the
@@ -337,11 +331,7 @@ class VersionAdmin(admin.ModelAdmin):
         # Display message
         messages.success(request, _("Version published"))
         # Redirect
-        url = reverse('admin:{app}_{model}_changelist'.format(
-            app=self.model._meta.app_label,
-            model=self.model._meta.model_name,
-        )) + '?grouper=' + str(version.grouper.pk)
-        return redirect(url)
+        return redirect(version_list_url(version.content))
 
     def unpublish_view(self, request, object_id):
         """Unpublishes the specified version and redirects back to the
@@ -364,11 +354,7 @@ class VersionAdmin(admin.ModelAdmin):
         # Display message
         messages.success(request, _("Version unpublished"))
         # Redirect
-        url = reverse('admin:{app}_{model}_changelist'.format(
-            app=self.model._meta.app_label,
-            model=self.model._meta.model_name,
-        )) + '?grouper=' + str(version.grouper.pk)
-        return redirect(url)
+        return redirect(version_list_url(version.content))
 
     def _get_edit_redirect_version(self, request, object_id):
         version = self.get_object(request, unquote(object_id))

--- a/djangocms_versioning/constants.py
+++ b/djangocms_versioning/constants.py
@@ -9,3 +9,5 @@ VERSION_STATES = (
     (UNPUBLISHED, 'Unpublished'),
     (ARCHIVED, 'Archived'),
 )
+
+GROUPER_PARAM = 'grouper'

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -151,7 +151,7 @@ def _version_list_url(versionable, **params):
             app=proxy._meta.app_label,
             model=proxy._meta.model_name,
         )),
-        **params,
+        **params
     )
 
 

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -5,8 +5,12 @@ from django.contrib import admin
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 
+from cms.utils.urlutils import add_url_parameters, admin_reverse
+
+from .constants import GROUPER_PARAM
 from .managers import PublishedContentManagerMixin
 from .models import Version
+from .versionables import _cms_extension
 
 
 def versioning_admin_factory(admin_class):
@@ -138,3 +142,35 @@ def override_default_manager(model, manager):
     _set_default_manager(model, manager)
     yield
     _set_default_manager(model, original_manager)
+
+
+def _version_list_url(versionable, **params):
+    proxy = versionable.version_model_proxy
+    return add_url_parameters(
+        admin_reverse('{app}_{model}_changelist'.format(
+            app=proxy._meta.app_label,
+            model=proxy._meta.model_name,
+        )),
+        **params,
+    )
+
+
+def version_list_url(content):
+    """Returns a URL to list of content model versions,
+    filtered by `content`'s grouper
+    """
+    versionable = _cms_extension().versionables_by_content[content.__class__]
+    grouper = getattr(content, versionable.grouper_field_name)
+    return _version_list_url(versionable, **{
+        GROUPER_PARAM: str(grouper.pk)
+    })
+
+
+def version_list_url_for_grouper(grouper):
+    """Returns a URL to list of content model versions,
+    filtered by `grouper`
+    """
+    versionable = _cms_extension().versionables_by_grouper[grouper.__class__]
+    return _version_list_url(versionable, **{
+        GROUPER_PARAM: str(grouper.pk)
+    })

--- a/tests/test_version_list.py
+++ b/tests/test_version_list.py
@@ -1,0 +1,24 @@
+from cms.test_utils.testcases import CMSTestCase
+
+from djangocms_versioning.helpers import (
+    version_list_url,
+    version_list_url_for_grouper,
+)
+from djangocms_versioning.test_utils import factories
+
+
+class VersionListUrlsTestCase(CMSTestCase):
+
+    def test_version_list_url(self):
+        pv = factories.PollVersionFactory()
+        self.assertEqual(
+            version_list_url(pv.content),
+            "/en/admin/djangocms_versioning/pollcontentversion/?grouper=1",
+        )
+
+    def test_version_list_url_for_grouper(self):
+        pv = factories.PollVersionFactory()
+        self.assertEqual(
+            version_list_url_for_grouper(pv.grouper),
+            "/en/admin/djangocms_versioning/pollcontentversion/?grouper=1",
+        )


### PR DESCRIPTION
There are two functions available, `version_list_url` should be preferred, unless content object is unavailable (example: https://github.com/divio/djangocms-alias/blob/214a08a3f76192f8dace7a02c797ecba90d9f3c7/djangocms_alias/models.py#L134). `version_list_url` will be extended to language-awareness later on.