### PR TITLE
Create a toolbar test helper for other apps to reuse. 

### DIFF
--- a/djangocms_versioning/test_utils/test_helpers.py
+++ b/djangocms_versioning/test_utils/test_helpers.py
@@ -1,0 +1,77 @@
+from django.test import RequestFactory
+
+from cms.toolbar.toolbar import CMSToolbar
+
+from djangocms_versioning.cms_toolbars import VersioningToolbar
+from djangocms_versioning.test_utils.factories import (
+    UserFactory,
+)
+
+
+def get_toolbar(content_obj, user=None, **kwargs):
+    """
+    Helper method to set up the toolbar
+
+    Warning: Other apps may use this helper to improve readability and stability of tests.
+            Be sure to keep backwards compatibility where possible
+    """
+    # Set the user if none are sent
+    if not user:
+        user = UserFactory(is_staff=True)
+
+    request = kwargs.get('request', RequestFactory().get('/'))
+    request.user = user
+    request.session = kwargs.get('session', {})
+    request.current_page = getattr(content_obj, 'page', None)
+    request.toolbar = CMSToolbar(request)
+    # Set the toolbar class
+    if kwargs.get('toolbar_class', False):
+        toolbar_class = kwargs.get('toolbar_class')
+    else:
+        toolbar_class = VersioningToolbar
+    toolbar = toolbar_class(
+        request,
+        toolbar=request.toolbar,
+        is_current_app=True,
+        app_path='/',
+    )
+    toolbar.toolbar.set_object(content_obj)
+    # Set the toolbar mode
+    if kwargs.get('edit_mode', False):
+        toolbar.toolbar.edit_mode_active = True
+        toolbar.toolbar.content_mode_active = False
+        toolbar.toolbar.structure_mode_active = False
+    elif kwargs.get('preview_mode', False):
+        toolbar.toolbar.edit_mode_active = False
+        toolbar.toolbar.content_mode_active = True
+        toolbar.toolbar.structure_mode_active = False
+    elif kwargs.get('structure_mode', False):
+        toolbar.toolbar.edit_mode_active = False
+        toolbar.toolbar.content_mode_active = False
+        toolbar.toolbar.structure_mode_active = True
+    toolbar.populate()
+    return toolbar
+
+
+def find_toolbar_buttons(button_name, toolbar):
+    """
+    Returns a button that matches the button name
+
+    Warning: Other apps may use this helper to improve readability and stability of tests.
+        Be sure to keep backwards compatibility where possible
+    """
+    found = []
+    for button_list in toolbar.get_right_items():
+        found = found + [button for button in button_list.buttons if button.name == button_name]
+    return found
+
+
+def toolbar_button_exists(button_name, toolbar):
+    """
+    Check to see if a button exists in a supplied toolbar
+
+    Warning: Other apps may use this helper to improve readability and stability of tests.
+        Be sure to keep backwards compatibility where possible
+    """
+    found = find_toolbar_buttons(button_name, toolbar)
+    return bool(len(found))

--- a/djangocms_versioning/test_utils/test_helpers.py
+++ b/djangocms_versioning/test_utils/test_helpers.py
@@ -3,9 +3,7 @@ from django.test import RequestFactory
 from cms.toolbar.toolbar import CMSToolbar
 
 from djangocms_versioning.cms_toolbars import VersioningToolbar
-from djangocms_versioning.test_utils.factories import (
-    UserFactory,
-)
+from djangocms_versioning.test_utils.factories import UserFactory
 
 
 def get_toolbar(content_obj, user=None, **kwargs):


### PR DESCRIPTION
This saves having to change every app when minor changes are made to the core CMS project.

Moderation and Version locking will reuse the test helpers, if in future the helper needs to diverge any of the projects can copy their own version. The idea is for now to standardise the tests and to help save time debugging as a lot of time has been spent debugging the different versions of this one helper that is repeated in all three projects.