### PR TITLE
Allow draft to be accessible from monkeypatched queryset

### DIFF
--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -59,6 +59,7 @@ class VersioningCMSExtension(CMSAppExtension):
         # First check that versioning is correctly defined
         if not isinstance(cms_config.versioning, collections.abc.Iterable):
             raise ImproperlyConfigured("versioning not defined as an iterable")
+
         for versionable in cms_config.versioning:
             if not isinstance(versionable, BaseVersionableItem):
                 raise ImproperlyConfigured(

--- a/djangocms_versioning/managers.py
+++ b/djangocms_versioning/managers.py
@@ -1,4 +1,29 @@
+from django.db import models
+from django.db.models.sql.where import WhereNode
+
 from .constants import PUBLISHED
+
+
+class PublishedQuerySet(models.QuerySet):
+
+    def get(self, *args, **kwargs):
+        """
+        A get query should always be able to access entries which are not in
+        a published state.
+        """
+        where_children = self.query.where.children
+        all_except_published = [
+            lookup for lookup in where_children
+            if not (
+                lookup.lookup_name == 'exact' and
+                lookup.rhs == 'published' and
+                lookup.lhs.field.name == 'state'
+            )
+        ]
+
+        self.query.where = WhereNode()
+        self.query.where.children = all_except_published
+        return super().get(*args, **kwargs)
 
 
 class PublishedContentManagerMixin:
@@ -8,7 +33,7 @@ class PublishedContentManagerMixin:
     def get_queryset(self):
         """Limit query to published content
         """
-        queryset = super().get_queryset()
+        queryset = PublishedQuerySet(self.model, using=self._db)
         if not self.versioning_enabled:
             return queryset
         return queryset.filter(versions__state=PUBLISHED)

--- a/djangocms_versioning/monkeypatch/page.py
+++ b/djangocms_versioning/monkeypatch/page.py
@@ -91,7 +91,6 @@ def create_title(func):
 
     return inner
 
-
 api.create_title = create_title(api.create_title)  # noqa: E305
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -47,13 +47,16 @@ class GrouperFormTestCase(CMSTestCase):
     def test_grouper_selector_non_default_label_unpublished(self):
         """
         Grouper selector shows the PageContent label format when PageContent is set
+
+        Because PublishedContentManager filters out draft content the label is not
+        str(version.content.title) but "No available title"
         """
         version = factories.PageVersionFactory()
         form_class = grouper_form_factory(PageContent, version.content.language)
-        label = "No available title (Unpublished)"
-        self.assertIn(
-            (version.content.page.pk, label), form_class.base_fields["page"].choices
-        )
+        label = "{} ({})".format("No available title", "Unpublished")
+
+        choices = list(form_class.base_fields["page"].choices)
+        self.assertIn((version.content.page.pk, label), choices)
 
     def test_grouper_selector_non_default_label(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -276,6 +276,18 @@ class TestVersionQuerySet(CMSTestCase):
         )
 
 
+class ManagerTestCase(CMSTestCase):
+    def setUp(self):
+        self.poll_version = factories.PollVersionFactory(content__language="en")
+
+    def test_draft_accessible_through_objects_get(self):
+        """Using objects.get works as expected for draft content"""
+        poll_content = PollContent.objects.get(pk=self.poll_version.content.pk)
+
+        self.assertEqual(self.poll_version.state, DRAFT)
+        self.assertEqual(self.poll_version.content.pk, poll_content.pk)
+
+
 class ModelsTestCase(CMSTestCase):
     def test_version_number_for_sequentially_created_versions(self):
         """


### PR DESCRIPTION
Only allowing published content to be available to be queried in the monkeypatched manager breaks any time `get` is used for draft content. 

~~It is more intuitive if all content is queryable as normal in the monkeypatched modelmanager, this won't also break any code that tries to access versionend content that is other than `published`.~~

~~Instead, it would be better to have published queryset on the manager. (not in this PR yet).~~

An alternative way of solving this would then be to allow all states to be accessible when making a get query. This would allow the use case of when looking up an entry through pk which would otherwise return `DoesNotExist`. 

**How to test manually**

Edit a page, add a new panel. Notice how when adding that new panel it won't reload the page as it did before. 