### PR TITLE
Fix admin change list empty translation / additional grouping values query error

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -6,6 +6,7 @@ from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.utils import flatten_fieldsets, unquote
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string, select_template
@@ -815,6 +816,7 @@ class VersionAdmin(admin.ModelAdmin):
             )
         except (TypeError, ValueError):
             grouper = None
+
         if grouper:
             extra_context.update(
                 grouper=grouper,
@@ -834,18 +836,24 @@ class VersionAdmin(admin.ModelAdmin):
             extra_context["breadcrumb_template"] = select_template(breadcrumb_templates)
 
         response = super().changelist_view(request, extra_context)
+
         # This is a slightly hacky way of accessing the instance of
         # the changelist that the admin changelist_view instantiates.
         # We do this to make sure that the latest content object is
         # picked from the same queryset as is being displayed in the
         # version table.
         if grouper and response.status_code == 200:
-            response.context_data["latest_content"] = (
-                response.context_data["cl"]
-                .get_queryset(request)
-                .latest("created")
-                .content
-            )
+            # Catch the edge case where a grouper can have empty contents
+            # when additional filters are present and the result set will be
+            # empty for the additional values.
+            try:
+                response.context_data["latest_content"] = (
+                    response.context_data["cl"].get_queryset(request)
+                        .latest("created")
+                        .content
+                )
+            except ObjectDoesNotExist:
+                pass
         return response
 
     def get_urls(self):

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -818,6 +818,9 @@ class VersionAdmin(admin.ModelAdmin):
             grouper = None
 
         if grouper:
+            # CAVEAT: as the breadcrumb trails expect a value for latest content in the template
+            extra_context["latest_content"] = ({'pk': None})
+
             extra_context.update(
                 grouper=grouper,
                 title=_('Displaying versions of "{grouper}"').format(grouper=grouper),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ TEST_REQUIREMENTS = [
     "djangocms-text-ckeditor",
     "factory-boy",
     "freezegun",
-    "lxml<=4.3.5"
+    "lxml<=4.3.5",
+    "bs4",
 ]
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2005,6 +2005,20 @@ class VersionChangeListViewTestCase(CMSTestCase):
             ordered=False,
         )
 
+    def test_view_language_on_item_with_no_language(self):
+        """A multi lingual model shows an empty version list when no
+        translation / language version exists for the grouper
+        """
+        changelist_url = self.get_admin_url(self.versionable.version_model_proxy, "changelist")
+        version1 = factories.PollVersionFactory(content__language="en")
+        version2 = factories.PollVersionFactory(content__language="en")
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(changelist_url, {"language": "fr", "poll": version1.content.poll_id})
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, response.context["cl"].queryset.count())
+
     def test_changelist_view_displays_correct_breadcrumbs(self):
         poll_content = factories.PollContentWithVersionFactory()
         url = self.get_admin_url(self.versionable.version_model_proxy, "changelist")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2016,7 +2016,7 @@ class VersionChangeListViewTestCase(CMSTestCase):
             response = self.client.get(changelist_url, {"language": "fr", "poll": version.content.poll_id})
 
         self.assertEqual(200, response.status_code)
-        self.assertEqual(2, response.context["cl"].queryset.count())
+        self.assertEqual(0, response.context["cl"].queryset.count())
 
     def test_view_language_on_polls_with_language_content(self):
         """A multi lingual model shows the correct values when


### PR DESCRIPTION
When a versioned model with additional grouping values is selected in the Admin the following error is thrown:

```
DoesNotExist at /admin/djangocms_versioning/menucontentversion/
MenuContentVersion matching query does not exist.
http://127.0.0.1:8000/admin/djangocms_versioning/menucontentversion/?language=ja&menu=29

/usr/local/lib/python3.6/site-packages/djangocms_versioning/admin.py in changelist_view
Line 846 .latest("created") 
```

The error is thrown because the language filtered is empty.

Steps to replicate:
1. Create a page with multiple languages
2. Add content to one of the languages
3. Go to the admin changelist
4. Select the filter for the language that has no content
5. Bosh, error thrown.

Images showing the error before the fix in this PR: 
![2019-11-26_admin-changelist-empty-translation-query-error-no-contents](https://user-images.githubusercontent.com/12543977/69620942-13854180-1036-11ea-933a-49094d8f3d45.png)
![2019-11-26_admin-changelist-empty-translation-query-error-no-contents-2](https://user-images.githubusercontent.com/12543977/69620943-13854180-1036-11ea-8db5-5cee4006c496.png)
![2019-11-26_admin-changelist-empty-translation-query-error-with-contents](https://user-images.githubusercontent.com/12543977/69620944-141dd800-1036-11ea-8231-df9d116f5b26.png)

Images showing no error with the changes in this PR using: "https://github.com/FidelityInternational/djangocms-versioning/archive/bugfix/admin-changelist-empty-translation-query-error.zip#egg=djangocms-versioning==0.0.23"
![2019-11-26_admin-changelist-empty-translation-query-error-fixed-no-contents](https://user-images.githubusercontent.com/12543977/69620945-141dd800-1036-11ea-9fbd-b9f5af366300.png)
![2019-11-26_admin-changelist-empty-translation-query-error-fixed-with-contents](https://user-images.githubusercontent.com/12543977/69620946-141dd800-1036-11ea-9530-ed26491079af.png)
