### PR TITLE
Support django2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,10 @@ jobs:
     <<: *py35default
   py36-dj21-sqlite-cms40:
     <<: *py36default
+  py35-dj22-sqlite-cms40:
+    <<: *py35default
+  py36-dj22-sqlite-cms40:
+    <<: *py36default
 
 #######################
 
@@ -142,5 +146,11 @@ workflows:
           requires:
             - py35_base
       - py36-dj21-sqlite-cms40:
+          requires:
+            - py36_base
+      - py35-dj22-sqlite-cms40:
+          requires:
+            - py35_base
+      - py36-dj22-sqlite-cms40:
           requires:
             - py36_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,5 @@
 version: 2.0
 
-py34default: &py34default
-  docker:
-    - image: circleci/python:3.4
-  steps:
-   - setup_remote_docker:
-       docker_layer_caching: false
-   - checkout
-   - attach_workspace:
-       at: /tmp/images
-   - run: docker load -i /tmp/images/py34.tar || true
-   - run: docker run py34 tox -e $CIRCLE_STAGE
-
 py35default: &py35default
   docker:
     - image: circleci/python:3.5
@@ -36,9 +24,17 @@ py36default: &py36default
    - run: docker load -i /tmp/images/py36.tar || true
    - run: docker run py36 tox -e $CIRCLE_STAGE
 
-py34_requires: &py34_requires
-  requires:
-    - py34_base
+py37default: &py37default
+   docker:
+     - image: circleci/python:3.7
+   steps:
+    - setup_remote_docker:
+        docker_layer_caching: false
+    - checkout
+    - attach_workspace:
+        at: /tmp/images
+    - run: docker load -i /tmp/images/py37.tar || true
+    - run: docker run py37 tox -e $CIRCLE_STAGE
 
 py35_requires: &py35_requires
   requires:
@@ -48,20 +44,11 @@ py36_requires: &py36_requires
   requires:
     - py36_base
 
+py37_requires: &py37_requires
+    requires:
+      - py37_base
+
 jobs:
-  py34_base:
-    docker:
-      - image: circleci/python:3.4
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.4 -t py34 .
-      - run: mkdir images
-      - run: docker save -o images/py34.tar py34
-      - persist_to_workspace:
-         root: images
-         paths: py34.tar
   py35_base:
     docker:
       - image: circleci/python:3.5
@@ -88,29 +75,50 @@ jobs:
       - persist_to_workspace:
          root: images
          paths: py36.tar
+  py37_base:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.7 -t py37 .
+      - run: mkdir images
+      - run: docker save -o images/py37.tar py37
+      - persist_to_workspace:
+         root: images
+         paths: py37.tar
 
   flake8:
     <<: *py35default
   isort:
     <<: *py35default
-  py34-dj111-sqlite-cms40:
-    <<: *py34default
+
   py35-dj111-sqlite-cms40:
     <<: *py35default
   py36-dj111-sqlite-cms40:
     <<: *py36default
+
   py35-dj20-sqlite-cms40:
     <<: *py35default
   py36-dj20-sqlite-cms40:
     <<: *py36default
+  py37-dj20-sqlite-cms40:
+    <<: *py37default
+
   py35-dj21-sqlite-cms40:
     <<: *py35default
   py36-dj21-sqlite-cms40:
     <<: *py36default
+  py37-dj21-sqlite-cms40:
+    <<: *py37default
+
   py35-dj22-sqlite-cms40:
     <<: *py35default
   py36-dj22-sqlite-cms40:
     <<: *py36default
+  py37-dj22-sqlite-cms40:
+    <<: *py37default
 
 #######################
 
@@ -118,39 +126,52 @@ workflows:
   version: 2
   build:
     jobs:
-      - py34_base
       - py35_base
       - py36_base
+      - py37_base
       - flake8:
           requires:
             - py35_base
       - isort:
           requires:
             - py35_base
-      - py34-dj111-sqlite-cms40:
-          requires:
-            - py34_base
       - py35-dj111-sqlite-cms40:
           requires:
             - py35_base
       - py36-dj111-sqlite-cms40:
           requires:
             - py36_base
+
+
       - py35-dj20-sqlite-cms40:
           requires:
             - py35_base
       - py36-dj20-sqlite-cms40:
           requires:
             - py36_base
+      - py37-dj20-sqlite-cms40:
+          requires:
+            - py37_base
+
+
       - py35-dj21-sqlite-cms40:
           requires:
             - py35_base
       - py36-dj21-sqlite-cms40:
           requires:
             - py36_base
+      - py37-dj21-sqlite-cms40:
+          requires:
+            - py37_base
+
+
       - py35-dj22-sqlite-cms40:
           requires:
             - py35_base
       - py36-dj22-sqlite-cms40:
           requires:
             - py36_base
+      - py37-dj22-sqlite-cms40:
+          requires:
+            - py37_base
+

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Testing
 
 To run all the tests the only thing you need to do is run
 
+    pip install -r tests/requirements.txt
     python setup.py test
 
 

--- a/djangocms_versioning/monkeypatch/toolbar.py
+++ b/djangocms_versioning/monkeypatch/toolbar.py
@@ -1,4 +1,4 @@
-from django.utils.functional import cached_property
+from functools import lru_cache
 
 from cms.toolbar import toolbar
 
@@ -8,17 +8,19 @@ from djangocms_versioning.plugin_rendering import (
 )
 
 
+@lru_cache(16)
 def content_renderer(self):
     return VersionContentRenderer(request=self.request)
 
 
-toolbar.CMSToolbar.content_renderer = cached_property(content_renderer)  # noqa: E305
+toolbar.CMSToolbar.content_renderer = property(content_renderer)  # noqa: E305
 
 
+@lru_cache(16)
 def structure_renderer(self):
     return VersionStructureRenderer(request=self.request)
 
 
-toolbar.CMSToolbar.structure_renderer = cached_property(
+toolbar.CMSToolbar.structure_renderer = property(
     structure_renderer
 )  # noqa: E305

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     tests_require=TEST_REQUIREMENTS,
     dependency_links=[
-        "https://github.com/jonathan-s/django-cms/tarball/django-2.2#egg=django-cms-4.0.0",
+        "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
         "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import djangocms_versioning
 
 
 INSTALL_REQUIREMENTS = [
-    "Django>=1.11,<2.2",
+    "Django>=1.11,<3.0",
     "django-cms",
     "django-fsm>=2.6,<2.7"
 ]
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     tests_require=TEST_REQUIREMENTS,
     dependency_links=[
-        "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
+        "https://github.com/jonathan-s/django-cms/tarball/django-2.2#egg=django-cms-4.0.0",
         "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x",
     ]
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,5 +4,6 @@ pyflakes>=2.1.1
 flake8
 isort
 mock
+python-dateutil
 
 beautifulsoup4

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     flake8
     isort
     py{34,35,36}-dj{111,20}-sqlite-cms40
-    py{35,36}-dj21-sqlite-cms40
+    py{35,36}-dj{21,22}-sqlite-cms40
 
 skip_missing_interpreters=True
 
@@ -14,8 +14,9 @@ deps =
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<3.0
 
-    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
+    cms40: https://github.com/jonathan-s/django-cms/archive/django-2.2.zip
 
 basepython =
     py34: python3.4

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist =
     flake8
     isort
-    py{34,35,36}-dj{111,20}-sqlite-cms40
-    py{35,36}-dj{21,22}-sqlite-cms40
+    py{35,36,37}-dj{111,20,21,22}-sqlite-cms40
 
 skip_missing_interpreters=True
 
@@ -19,9 +18,9 @@ deps =
     cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 
 commands =
     {envpython} --version

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
 
-    cms40: https://github.com/jonathan-s/django-cms/archive/django-2.2.zip
+    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 
 basepython =
     py34: python3.4


### PR DESCRIPTION
Currently it's failing so this a WIP investigation to figure out why. 

TypeError: Cannot use cached_property instance without calling `__set_name__()` on it.

when `__set_name__` is being called on the cached property, the cached property function is being replaced by the real function. 

When `__set_name__` is not called, this replacement does not happen, which executes the cached property function which subsequently throws an error. 

So for some reason cached property's `__set_name__` is not being called even though it should be. 

Django had a similar bug where this happened: 
- https://github.com/django/django/pull/10763/files
- https://code.djangoproject.com/ticket/29970

This is the error that is being thrown for `cached_property`
https://github.com/django/django/blob/stable/2.2.x/django/utils/functional.py#L31

Docs for cached_property in django 2.2: https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.functional.cached_property

**edit** 
I'm now 80% sure it's because we are monkey patching content_renderer and structure_renderer, right here: https://github.com/divio/djangocms-versioning/blob/master/djangocms_versioning/monkeypatch/toolbar.py

Changing `cached_property` to a `property` confirms that fact. It is the issue. A different issue crops up if you make that change.
