### PR TITLE
Urls no longer need to be updated

### DIFF
--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -213,7 +213,6 @@ def on_page_content_unpublish(version):
     """Url path and cache operations to do when a PageContent obj is unpublished"""
     page = version.content.page
     language = version.content.language
-    page.update_urls(language, path=None)
     page._update_url_path_recursive(language)
     page.clear_cache(menu=True)
 

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -4,7 +4,8 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 
-from cms.models import Page, PageContent, Placeholder, TreeNode
+from cms import constants
+from cms.models import Page, PageContent, PageUrl, Placeholder, TreeNode
 
 import factory
 from djangocms_text_ckeditor.models import Text
@@ -139,6 +140,16 @@ class TreeNodeFactory(factory.django.DjangoModelFactory):
         model = TreeNode
 
 
+class PageUrlFactory(factory.django.DjangoModelFactory):
+    slug = ''
+    path = ''
+    managed = False
+    language = 'en'
+
+    class Meta:
+        model = PageUrl
+
+
 class PageFactory(factory.django.DjangoModelFactory):
     node = factory.SubFactory(TreeNodeFactory)
 
@@ -159,7 +170,7 @@ class PageContentFactory(factory.django.DjangoModelFactory):
     in_navigation = FuzzyChoice([True, False])
     soft_root = FuzzyChoice([True, False])
     template = FuzzyText(length=12)
-    limit_visibility_in_menu = FuzzyInteger(0, 25)
+    limit_visibility_in_menu = constants.VISIBILITY_USERS
     xframe_options = FuzzyInteger(0, 25)
 
     class Meta:


### PR DESCRIPTION
The urls does not need to be updated at all. The reason urls
were presumably updated in the past was to avoid that you could
visit a page if the page was in draft mode.

This has been fixed in django-cms. A page that is in draft
will return an EmptyPageContent, if it is empty it won't render.

See divio/django-cms#6803

Added tests are mostly for documentation purposes to see expected behaviour. 

From @jonathan-s 11th Feb 2020 justifying why we need to make this change:

On the off chance that there is a page that uses the old structure and there is a change that requires it I've left it in. 
 
So the scenario is the following. User creates a page, pagecontent is in draft. User publishes pagecontent. They change the path to something custom (this sets managed to False in that url). Prior to this patch everything works fine. With this setup.
 
User creates a new version. User publishes this. This means that the prior version gets unpublished. So the page url would have been set to none. New version gets published. Since only managed urls gets updated (there is no way to refresh unmanaged urls as they are static and the static thing was just deleted). 
 
With this patch we avoid setting urls to None since this is no longer necessary. We've solved the findability of a page in core-cms. 

@Aiky30 would like to add that as there were no tests for the changes originally it's very difficult to know why the features were there in the first place, we could only assume!!

Changes made with no reasoning of why:
- https://github.com/divio/djangocms-versioning/pull/61
- https://github.com/divio/djangocms-versioning/pull/62