### PR TITLE
Monkeypatch so that draft object can be retrieved

### DIFF
--- a/djangocms_versioning/monkeypatch/admin.py
+++ b/djangocms_versioning/monkeypatch/admin.py
@@ -1,4 +1,5 @@
 from cms import admin
+from cms.utils import helpers
 
 from .. import versionables
 
@@ -18,3 +19,10 @@ def get_queryset(func):
 admin.pageadmin.PageContentAdmin.get_queryset = get_queryset(
     admin.pageadmin.PageContentAdmin.get_queryset
 )
+
+
+def get_admin_model_object_by_id(model_class, obj_id):
+    return model_class._original_manager.get(pk=obj_id)
+
+
+helpers.get_admin_model_object_by_id = get_admin_model_object_by_id

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -2,6 +2,7 @@ from django.contrib.sites.models import Site
 
 from cms.cms_toolbars import LANGUAGE_MENU_IDENTIFIER
 from cms.extensions.extension_pool import ExtensionPool
+from cms.models import PageContent
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url
@@ -59,6 +60,20 @@ class MonkeypatchTestCase(CMSTestCase):
         self.assertEqual(
             CMSToolbar(request).content_renderer.__class__, VersionContentRenderer
         )
+
+    def test_get_admin_model_object(self):
+        """
+        PageContent normally won't be able to fetch objects in draft.
+        With the mocked get_admin_model_object_by_id it is able to fetch objects
+        in draft mode.
+        """
+        from cms.utils.helpers import get_admin_model_object_by_id
+
+        version = PageVersionFactory()
+        content = get_admin_model_object_by_id(PageContent, version.content.pk)
+
+        self.assertEqual(version.state, 'draft')
+        self.assertEqual(content.pk, version.content.pk)
 
     def test_success_url_for_cms_wizard(self):
         from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard


### PR DESCRIPTION
`RequestToolbarForm` in django-cms needs to be able to fetch objects that are in draft as well. A method `get_admin_model_object_by_id` was created in the following PR (https://github.com/divio/django-cms/pull/6806) to allow versioning to monkeypatch this method. 