### PR TITLE
Mock filter_admin_model

### DIFF
--- a/djangocms_versioning/monkeypatch/admin.py
+++ b/djangocms_versioning/monkeypatch/admin.py
@@ -1,4 +1,5 @@
 from cms import admin
+from cms.utils import helpers
 
 from .. import versionables
 
@@ -18,3 +19,10 @@ def get_queryset(func):
 admin.pageadmin.PageContentAdmin.get_queryset = get_queryset(
     admin.pageadmin.PageContentAdmin.get_queryset
 )
+
+
+def filter_admin_model(model_class, **kwargs):
+    return model_class._original_manager.filter(**kwargs)
+
+
+helpers.filter_admin_model = filter_admin_model

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -2,6 +2,7 @@ from django.contrib.sites.models import Site
 
 from cms.cms_toolbars import LANGUAGE_MENU_IDENTIFIER
 from cms.extensions.extension_pool import ExtensionPool
+from cms.models import PageContent
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url
@@ -59,6 +60,20 @@ class MonkeypatchTestCase(CMSTestCase):
         self.assertEqual(
             CMSToolbar(request).content_renderer.__class__, VersionContentRenderer
         )
+
+    def test_filter_admin_model(self):
+        """
+        PageContent normally won't be able to fetch objects in draft.
+        With the mocked get_admin_model_object_by_id it is able to fetch objects
+        in draft mode.
+        """
+        from cms.utils.helpers import filter_admin_model
+
+        version = PageVersionFactory()
+        content = filter_admin_model(PageContent, pk=version.content.pk).first()
+
+        self.assertEqual(version.state, 'draft')
+        self.assertEqual(content.pk, version.content.pk)
 
     def test_success_url_for_cms_wizard(self):
         from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard


### PR DESCRIPTION
By mocking this method we will be able to filter from the entire queryset
rather than the queryset limited to published objects

The reason for introducing this in the first place was that the toolbar needs to access to be able to access an object that is draft and it should not rely on `page.get_title` to fetch the correct object as that method will fetch fallbacks which may not be correct for our purposes. 

This PR depends on: https://github.com/divio/django-cms/pull/6817 for tests to succeed. 