### PR TITLE
Move duplicate view from pageadmin to versioning

### DIFF
--- a/djangocms_versioning/admin/__init__.py
+++ b/djangocms_versioning/admin/__init__.py
@@ -1,0 +1,2 @@
+from .pageadmin import *  # noqa
+from .versioning import *  # noqa

--- a/djangocms_versioning/admin/pageadmin.py
+++ b/djangocms_versioning/admin/pageadmin.py
@@ -1,0 +1,222 @@
+from django.conf.urls import url
+from django.contrib.admin.utils import flatten_fieldsets, unquote
+from django.db import transaction
+from django.shortcuts import redirect, render
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
+
+from cms import api
+from cms.extensions import extension_pool
+from cms.models import PageContent
+
+from djangocms_versioning import versionables
+from djangocms_versioning.compat import DJANGO_GTE_21
+from djangocms_versioning.forms import DuplicateForm
+from djangocms_versioning.models import Version
+
+
+class VersioningChangeListMixin:
+    """Mixin used for ChangeList classes of content models."""
+
+    def get_queryset(self, request):
+        """Limit the content model queryset to latest versions only."""
+        queryset = super().get_queryset(request)
+        versionable = versionables.for_content(queryset.model)
+        return queryset.filter(pk__in=versionable.distinct_groupers())
+
+
+def versioning_change_list_factory(base_changelist_cls):
+    """Generate a ChangeList class to use for the content model"""
+    return type(
+        "Versioned" + base_changelist_cls.__name__,
+        (VersioningChangeListMixin, base_changelist_cls),
+        {}
+    )
+
+
+class VersioningAdminMixin:
+    """Mixin providing versioning functionality to admin classes of
+    content models.
+    """
+
+    def save_model(self, request, obj, form, change):
+        """
+        Overrides the save method to create a version object
+        when a content object is created
+        """
+        super().save_model(request, obj, form, change)
+        if not change:
+            if isinstance(obj, PageContent):
+                # FIXME disabled version creation for `cms.PageContent`
+                # here, as it's already done in `cms.api.create_title`
+                return
+            # create a new version object and save it
+            Version.objects.create(content=obj, created_by=request.user)
+
+    def get_queryset(self, request):
+        """Override manager so records not in published state can be displayed"""
+        from ..helpers import override_default_manager
+
+        with override_default_manager(self.model, self.model._original_manager):
+            queryset = super().get_queryset(request)
+        return queryset
+
+    def get_changelist(self, request, **kwargs):
+        ChangeList = super().get_changelist(request, **kwargs)
+        return versioning_change_list_factory(ChangeList)
+
+    change_form_template = "djangocms_versioning/admin/mixin/change_form.html"
+
+    def render_change_form(
+        self, request, context, add=False, change=False, form_url="", obj=None
+    ):
+        """Add a link to the version table to the change form view"""
+        if "versioning_fallback_change_form_template" not in context:
+            context[
+                "versioning_fallback_change_form_template"
+            ] = super().change_form_template
+
+        return super().render_change_form(request, context, add, change, form_url, obj)
+
+    def get_readonly_fields(self, request, obj=None):
+        """Port permission code from django >= 2.1.
+
+        In later versions of django if a user has view perms but no
+        change perms, fields are set as read-only. This is not the case
+        in django < 2.1.
+        """
+        if obj and not DJANGO_GTE_21:
+            version = Version.objects.get_for_content(obj)
+            if not version.check_modify.as_bool(request.user):
+                if self.fields:
+                    return self.fields
+                if self.fieldsets:
+                    return flatten_fieldsets(self.fieldsets)
+                if self.form.declared_fields:
+                    return self.form.declared_fields
+                return list(
+                    set(
+                        [field.name for field in self.opts.local_fields]
+                        + [field.name for field in self.opts.local_many_to_many]
+                    )
+                )
+        return super().get_readonly_fields(request, obj)
+
+    def has_change_permission(self, request, obj=None):
+        if obj and DJANGO_GTE_21:
+            version = Version.objects.get_for_content(obj)
+            return version.check_modify.as_bool(request.user)
+        return super().has_change_permission(request, obj)
+
+
+class VersioningPageContentAdminMixin(VersioningAdminMixin):
+
+    def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+        if obj:
+            version = Version.objects.get_for_content(obj)
+            if not version.check_modify.as_bool(request.user):
+                form = self.get_form_class(request)
+                if getattr(form, "fieldsets"):
+                    fields = flatten_fieldsets(form.fieldsets)
+                fields = list(fields)
+                for f_name in ["slug", "overwrite_url"]:
+                    fields.remove(f_name)
+        return fields
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        if obj:
+            version = Version.objects.get_for_content(obj)
+            if not version.check_modify.as_bool(request.user):
+                for f_name in ["slug", "overwrite_url"]:
+                    form.declared_fields[f_name].widget.attrs["readonly"] = True
+        return form
+
+    def get_urls(self):
+        info = self.model._meta.app_label, self.model._meta.model_name
+        # we replace the duplicate with our function.
+        old_urls = [v for v in super().get_urls() if 'duplicate' not in str(v.name)]
+        new_urls = [
+            url(
+                r"^(.+)/duplicate-content/$",
+                self.admin_site.admin_view(self.duplicate_view),
+                name="{}_{}_duplicate".format(*info),
+            ),
+        ]
+        return new_urls + old_urls
+
+    @transaction.atomic
+    def duplicate_view(self, request, object_id):
+        """Duplicate a specified PageContent.
+
+        Create a new page with content copied from provided PageContent.
+
+        :param request: Http request
+        :param object_id: PageContent ID (as a string)
+        """
+        obj = self.get_object(request, unquote(object_id))
+        if obj is None:
+            return self._get_obj_does_not_exist_redirect(
+                request, self.model._meta, object_id
+            )
+
+        form = DuplicateForm(
+            user=request.user,
+            page_content=obj,
+            initial={
+                "site": obj.page.node.site,
+                "slug": obj.page.get_slug(obj.language),
+            },
+        )
+        info = (self.model._meta.app_label, self.model._meta.model_name)
+        if request.method == "POST":
+            form = DuplicateForm(request.POST, user=request.user, page_content=obj)
+            if form.is_valid():
+                new_page = obj.page.copy(
+                    site=form.cleaned_data["site"],
+                    parent_node=obj.page.node.parent,
+                    translations=False,
+                    permissions=False,
+                    extensions=False,
+                )
+
+                new_page_content = api.create_title(
+                    page=new_page,
+                    language=obj.language,
+                    slug=form.cleaned_data["slug"],
+                    path=form.cleaned_data["path"],
+                    title=obj.title,
+                    template=obj.template,
+                    created_by=request.user,
+                )
+                new_page.title_cache[obj.language] = new_page_content
+
+                extension_pool.copy_extensions(
+                    source_page=obj.page, target_page=new_page, languages=[obj.language]
+                )
+
+                placeholders = obj.get_placeholders()
+                for source_placeholder in placeholders:
+                    target_placeholder, created = new_page_content.placeholders.get_or_create(
+                        slot=source_placeholder.slot
+                    )
+                    source_placeholder.copy_plugins(
+                        target_placeholder, language=obj.language
+                    )
+
+                self.message_user(request, _("Page has been duplicated"))
+                return redirect(reverse("admin:{}_{}_changelist".format(*info)))
+
+        context = dict(
+            obj=obj,
+            form=form,
+            object_id=object_id,
+            duplicate_url=reverse(
+                "admin:{}_{}_duplicate".format(*info), args=(obj.pk,)
+            ),
+            back_url=reverse("admin:{}_{}_changelist".format(*info)),
+        )
+        return render(
+            request, "djangocms_versioning/admin/duplicate_page_confirmation.html", context
+        )

--- a/djangocms_versioning/admin/versioning.py
+++ b/djangocms_versioning/admin/versioning.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin.options import IncorrectLookupParameters
-from django.contrib.admin.utils import flatten_fieldsets, unquote
+from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
@@ -16,113 +16,17 @@ from django.utils.encoding import force_text
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
 
-from cms.models import PageContent
 from cms.utils import get_language_from_request
 from cms.utils.conf import get_cms_setting
 from cms.utils.urlutils import add_url_parameters
 
-from . import versionables
-from .compat import DJANGO_GTE_21
-from .constants import ARCHIVED, DRAFT, PUBLISHED, UNPUBLISHED
-from .exceptions import ConditionFailed
-from .forms import grouper_form_factory
-from .helpers import get_admin_url, get_editable_url, get_preview_url, version_list_url
-from .models import Version
-from .versionables import _cms_extension
-
-
-class VersioningChangeListMixin:
-    """Mixin used for ChangeList classes of content models."""
-
-    def get_queryset(self, request):
-        """Limit the content model queryset to latest versions only."""
-        queryset = super().get_queryset(request)
-        versionable = versionables.for_content(queryset.model)
-        return queryset.filter(pk__in=versionable.distinct_groupers())
-
-
-def versioning_change_list_factory(base_changelist_cls):
-    """Generate a ChangeList class to use for the content model"""
-    return type(
-        "Versioned" + base_changelist_cls.__name__,
-        (VersioningChangeListMixin, base_changelist_cls),
-        {}
-    )
-
-
-class VersioningAdminMixin:
-    """Mixin providing versioning functionality to admin classes of
-    content models.
-    """
-
-    def save_model(self, request, obj, form, change):
-        """
-        Overrides the save method to create a version object
-        when a content object is created
-        """
-        super().save_model(request, obj, form, change)
-        if not change:
-            if isinstance(obj, PageContent):
-                # FIXME disabled version creation for `cms.PageContent`
-                # here, as it's already done in `cms.api.create_title`
-                return
-            # create a new version object and save it
-            Version.objects.create(content=obj, created_by=request.user)
-
-    def get_queryset(self, request):
-        """Override manager so records not in published state can be displayed"""
-        from .helpers import override_default_manager
-
-        with override_default_manager(self.model, self.model._original_manager):
-            queryset = super().get_queryset(request)
-        return queryset
-
-    def get_changelist(self, request, **kwargs):
-        ChangeList = super().get_changelist(request, **kwargs)
-        return versioning_change_list_factory(ChangeList)
-
-    change_form_template = "djangocms_versioning/admin/mixin/change_form.html"
-
-    def render_change_form(
-        self, request, context, add=False, change=False, form_url="", obj=None
-    ):
-        """Add a link to the version table to the change form view"""
-        if "versioning_fallback_change_form_template" not in context:
-            context[
-                "versioning_fallback_change_form_template"
-            ] = super().change_form_template
-
-        return super().render_change_form(request, context, add, change, form_url, obj)
-
-    def get_readonly_fields(self, request, obj=None):
-        """Port permission code from django >= 2.1.
-
-        In later versions of django if a user has view perms but no
-        change perms, fields are set as read-only. This is not the case
-        in django < 2.1.
-        """
-        if obj and not DJANGO_GTE_21:
-            version = Version.objects.get_for_content(obj)
-            if not version.check_modify.as_bool(request.user):
-                if self.fields:
-                    return self.fields
-                if self.fieldsets:
-                    return flatten_fieldsets(self.fieldsets)
-                if self.form.declared_fields:
-                    return self.form.declared_fields
-                return list(
-                    set(
-                        [field.name for field in self.opts.local_fields]
-                        + [field.name for field in self.opts.local_many_to_many]
-                    )
-                )
-        return super().get_readonly_fields(request, obj)
-
-    def has_change_permission(self, request, obj=None):
-        if obj and DJANGO_GTE_21:
-            version = Version.objects.get_for_content(obj)
-            return version.check_modify.as_bool(request.user)
-        return super().has_change_permission(request, obj)
+from .. import versionables
+from ..constants import ARCHIVED, DRAFT, PUBLISHED, UNPUBLISHED
+from ..exceptions import ConditionFailed
+from ..forms import grouper_form_factory
+from ..helpers import get_admin_url, get_editable_url, get_preview_url, version_list_url
+from ..models import Version
+from ..versionables import _cms_extension
 
 
 class VersionChangeList(ChangeList):

--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -1,7 +1,6 @@
 import collections
 
 from django.conf import settings
-from django.contrib.admin.utils import flatten_fieldsets
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
@@ -10,7 +9,7 @@ from cms.app_base import CMSAppConfig, CMSAppExtension
 from cms.models import PageContent, Placeholder
 from cms.utils.i18n import get_language_tuple
 
-from .admin import VersioningAdminMixin
+from .admin import VersioningPageContentAdminMixin
 from .datastructures import BaseVersionableItem, VersionableItem
 from .helpers import (
     inject_generic_relation_to_version,
@@ -18,7 +17,6 @@ from .helpers import (
     replace_admin_for_models,
     replace_default_manager,
 )
-from .models import Version
 
 
 class VersioningCMSExtension(CMSAppExtension):
@@ -229,30 +227,6 @@ def on_page_content_archive(version):
     page.clear_cache(menu=True)
 
 
-class VersioningCMSPageAdminMixin(VersioningAdminMixin):
-    def get_readonly_fields(self, request, obj=None):
-        fields = super().get_readonly_fields(request, obj)
-        if obj:
-            version = Version.objects.get_for_content(obj)
-            if not version.check_modify.as_bool(request.user):
-                form = self.get_form_class(request)
-                if getattr(form, "fieldsets"):
-                    fields = flatten_fieldsets(form.fieldsets)
-                fields = list(fields)
-                for f_name in ["slug", "overwrite_url"]:
-                    fields.remove(f_name)
-        return fields
-
-    def get_form(self, request, obj=None, **kwargs):
-        form = super().get_form(request, obj, **kwargs)
-        if obj:
-            version = Version.objects.get_for_content(obj)
-            if not version.check_modify.as_bool(request.user):
-                for f_name in ["slug", "overwrite_url"]:
-                    form.declared_fields[f_name].widget.attrs["readonly"] = True
-        return form
-
-
 class VersioningCMSConfig(CMSAppConfig):
     """Implement versioning for core cms models
     """
@@ -272,6 +246,6 @@ class VersioningCMSConfig(CMSAppConfig):
             on_unpublish=on_page_content_unpublish,
             on_draft_create=on_page_content_draft_create,
             on_archive=on_page_content_archive,
-            content_admin_mixin=VersioningCMSPageAdminMixin,
+            content_admin_mixin=VersioningPageContentAdminMixin,
         )
     ]

--- a/djangocms_versioning/forms.py
+++ b/djangocms_versioning/forms.py
@@ -1,8 +1,67 @@
 from functools import lru_cache
 
 from django import forms
+from django.contrib.sites.models import Site
+from django.template.defaultfilters import slugify
+from django.utils.translation import ugettext_lazy as _
+
+from cms.forms.validators import validate_url_uniqueness
 
 from . import versionables
+
+
+class DuplicateForm(forms.Form):
+    site = forms.ModelChoiceField(
+        label=_("Site"),
+        queryset=Site.objects.all(),
+        help_text=_("Site in which the new page will be created"),
+    )
+    slug = forms.CharField(
+        label=_("Slug"),
+        max_length=255,
+        widget=forms.TextInput(),
+        help_text=_("The part of the title that is used in the URL"),
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop("user")
+        self.page_content = kwargs.pop("page_content")
+        super().__init__(*args, **kwargs)
+
+    def clean_slug(self):
+        slug = slugify(self.cleaned_data["slug"])
+        if not slug:
+            raise forms.ValidationError(_("Slug must not be empty."))
+        return slug
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if self.errors:
+            return cleaned_data
+
+        language = self.page_content.language
+
+        slug = cleaned_data["slug"]
+        if self.page_content.page.node.parent:
+            parent_path = self.page_content.page.node.parent.item.get_path(language)
+            path = "%s/%s" % (parent_path, slug) if parent_path else slug
+        else:
+            path = cleaned_data["slug"]
+
+        try:
+            validate_url_uniqueness(
+                cleaned_data["site"],
+                path=path,
+                language=language,
+                user_language=language,
+            )
+        except forms.ValidationError as e:
+            self.add_error("slug", e)
+        else:
+            cleaned_data["path"] = path
+
+        return cleaned_data
 
 
 class VersionContentChoiceField(forms.ModelChoiceField):

--- a/djangocms_versioning/plugin_rendering.py
+++ b/djangocms_versioning/plugin_rendering.py
@@ -46,7 +46,6 @@ class VersionContentRenderer(ContentRenderer):
         # code, which by default doesn't work well with versioning.
         # Remove this method once the issue is fixed.
         from cms.models import Placeholder
-
         current_obj = self.toolbar.get_object()
 
         # Not page, therefore we will use toolbar object as

--- a/djangocms_versioning/templates/djangocms_versioning/admin/duplicate_page_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/duplicate_page_confirmation.html
@@ -1,0 +1,29 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+{% block title %}{% trans "Duplicate confirmation" %}{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script type="text/javascript" src="{% static 'admin/js/cancel.js' %}"></script>
+{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
+
+{% block content %}
+<p>{% trans "Are you sure you want to duplicate the following page?" %}</p>
+<h3>{{ obj }}</h3>
+<form action="" method="POST">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input class="button confirm-link js-page-admin-keep-sideframe"
+           type="submit"
+           value="{% trans 'Yes, I\'m sure' %}">
+    <a href="{{ back_url }}">
+        <input type="button"
+               class="button js-page-admin-keep-sideframe"
+               value="{% trans 'No, take me back' %}">
+    </a>
+</form>
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ INSTALL_REQUIREMENTS = [
 
 TEST_REQUIREMENTS = [
     "djangocms_helper",
-    "pillow<=5.4.1",  # Requirement for tests to be passing in python 3.4
     "djangocms-text-ckeditor",
     "factory-boy",
     "freezegun",

--- a/tests/test_admin_using_versioning.py
+++ b/tests/test_admin_using_versioning.py
@@ -1,0 +1,173 @@
+from unittest.mock import patch
+
+import django
+from django.contrib import admin
+from django.contrib.sites.models import Site
+
+from cms.api import add_plugin
+from cms.models import PageContent, PageUrl
+from cms.test_utils.testcases import CMSTestCase
+from cms.utils.plugins import downcast_plugins
+
+from djangocms_versioning.test_utils.factories import (
+    PageContentWithVersionFactory,
+    PlaceholderFactory,
+)
+
+
+version = list(map(int, django.__version__.split('.')))
+GTE_DJ20 = version[0] >= 2
+
+
+class PageContentAdminTestCase(CMSTestCase):
+    def setUp(self):
+        self.modeladmin = admin.site._registry[PageContent]
+
+    def test_duplicate_url_is_replaced(self):
+        """
+        The old url /duplicate/ has been removed. But cms_pagecontent_duplicate
+        still exists.
+        """
+
+        urls = self.modeladmin.get_urls()
+        if GTE_DJ20:
+            duplicate_url = [u for u in urls if '/duplicate/' in u.pattern.regex.pattern]
+        else:
+            duplicate_url = [u for u in urls if '/duplicate/' in u.regex.pattern]
+        name_url = [u for u in urls if 'cms_pagecontent_duplicate' == u.name]
+
+        self.assertEqual(len(duplicate_url), 0)
+        self.assertEqual(len(name_url), 1)
+
+
+class DuplicateViewTestCase(CMSTestCase):
+    def test_obj_does_not_exist(self):
+        with self.login_user_context(self.get_superuser()), patch(
+            "django.contrib.messages.add_message"
+        ) as mock:
+            response = self.client.get(
+                self.get_admin_url(PageContent, "duplicate", "foo")
+            )
+
+        self.assertRedirects(response, "/en/admin/", target_status_code=302)
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(mock.call_args[0][1], 30)  # warning level
+        self.assertEqual(
+            mock.call_args[0][2],
+            'page content with ID "foo" doesn\'t exist. Perhaps it was deleted?',
+        )
+
+    def test_get(self):
+        pagecontent = PageContentWithVersionFactory()
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(
+                self.get_admin_url(PageContent, "duplicate", pagecontent.pk)
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(PageContent._base_manager.count(), 1)
+
+    def test_post_empty_slug(self):
+        pagecontent = PageContentWithVersionFactory()
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.post(
+                self.get_admin_url(PageContent, "duplicate", pagecontent.pk),
+                data={"slug": ""},
+            )
+            form = response.context["form"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(form.is_valid())
+        self.assertIn("slug", form.errors)
+        self.assertEqual(form.errors["slug"], ["This field is required."])
+
+    def test_post_empty_slug_after_slugify(self):
+        pagecontent = PageContentWithVersionFactory()
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.post(
+                self.get_admin_url(PageContent, "duplicate", pagecontent.pk),
+                data={"site": Site.objects.first().pk, "slug": "£"},
+            )
+            form = response.context["form"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(form.is_valid())
+        self.assertIn("slug", form.errors)
+        self.assertEqual(form.errors["slug"], ["Slug must not be empty."])
+
+    def test_post(self):
+        """the slot for content is always there, the slot for navigation needs
+        to be created"""
+        pagecontent = PageContentWithVersionFactory(template="page.html")
+        placeholder = PlaceholderFactory(slot="content", source=pagecontent)
+        PlaceholderFactory(slot="navigation", source=pagecontent)
+        add_plugin(placeholder, "TextPlugin", pagecontent.language, body="Test text")
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.post(
+                self.get_admin_url(PageContent, "duplicate", pagecontent.pk),
+                data={"site": Site.objects.first().pk, "slug": "foo bar"},
+                follow=True,
+            )
+
+        self.assertRedirects(response, self.get_admin_url(PageContent, "changelist"))
+        new_pagecontent = PageContent._base_manager.latest("pk")
+        new_placeholder = new_pagecontent.placeholders.get(slot="content")
+        self.assertEqual(PageContent._base_manager.count(), 2)
+        self.assertNotEqual(pagecontent, new_pagecontent)
+        self.assertNotEqual(pagecontent.page, new_pagecontent.page)
+        self.assertEqual(pagecontent.language, new_pagecontent.language)
+        self.assertEqual(
+            new_pagecontent.page.get_slug(new_pagecontent.language), "foo-bar"
+        )
+        new_plugins = list(downcast_plugins(new_placeholder.get_plugins_list()))
+
+        self.assertEqual(len(new_plugins), 1)
+        self.assertEqual(new_plugins[0].plugin_type, "TextPlugin")
+        self.assertEqual(new_plugins[0].body, "Test text")
+
+    def test_post_with_parent(self):
+        pagecontent1 = PageContentWithVersionFactory(
+            template="page.html",
+            page__node__depth=0,
+            page__node__path="0001",
+            page__node__numchild=1,
+        )
+        PageUrl.objects.create(
+            slug="foo",
+            path="foo",
+            language=pagecontent1.language,
+            page=pagecontent1.page,
+        )
+        pagecontent2 = PageContentWithVersionFactory(
+            template="page.html",
+            language=pagecontent1.language,
+            page__node__parent_id=pagecontent1.page.node_id,
+            page__node__depth=1,
+            page__node__path="00010001",
+        )
+        placeholder = PlaceholderFactory(slot="content", source=pagecontent2)
+        add_plugin(placeholder, "TextPlugin", pagecontent2.language, body="Test text")
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.post(
+                self.get_admin_url(PageContent, "duplicate", pagecontent2.pk),
+                data={"site": Site.objects.first().pk, "slug": "bar"},
+                follow=True,
+            )
+
+        self.assertRedirects(response, self.get_admin_url(PageContent, "changelist"))
+        new_pagecontent = PageContent._base_manager.latest("pk")
+        new_placeholder = new_pagecontent.placeholders.get(slot="content")
+        self.assertEqual(PageContent._base_manager.count(), 3)
+        self.assertNotEqual(pagecontent2, new_pagecontent)
+        self.assertNotEqual(pagecontent2.page, new_pagecontent.page)
+        self.assertEqual(pagecontent2.language, new_pagecontent.language)
+        self.assertEqual(
+            new_pagecontent.page.get_path(new_pagecontent.language), "foo/bar"
+        )
+        new_plugins = list(downcast_plugins(new_placeholder.get_plugins_list()))
+        self.assertEqual(len(new_plugins), 1)
+        self.assertEqual(new_plugins[0].plugin_type, "TextPlugin")
+        self.assertEqual(new_plugins[0].body, "Test text")


### PR DESCRIPTION
As described in this PR here -> https://github.com/FidelityInternational/djangocms-pageadmin/pull/45

We want to move the duplicate view from pageadmin to versioning. The reason for the need to make this move of the code is so that a person won't be required to install djangocms-pageadmin to not get an error when duplicating pagecontent. 

Next step is to remove code in pageadmin that is no longer needed. 