### PR TITLE
Fixed a JS load error inherited by all Admins from versioning

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -206,7 +206,7 @@ class VersionAdmin(admin.ModelAdmin):
     """
 
     class Media:
-        js = ("djangocms_versioning/js/actions.js",)
+        js = ("admin/js/jquery.init.js", "djangocms_versioning/js/actions.js",)
         css = {"all": ("djangocms_versioning/css/actions.css",)}
 
     # register custom actions

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -336,7 +336,7 @@ class VersioningPageToolbarTestCase(CMSTestCase):
         self.assertNotIn("Copy all plugins", language_menu_dict.keys())
 
         self.assertEquals(
-            set([l.name for l in language_menu_dict["Add Translation"]]),
+            set([lang.name for lang in language_menu_dict["Add Translation"]]),
             set(["Française..."]),
         )
 


### PR DESCRIPTION
In Django 2.2 a JS load error has started to occur in the Versioning admin. It's possibly due to the change of how Django now sorts Media assets: https://docs.djangoproject.com/en/3.0/releases/2.2/#merging-of-form-media-assets

A screenshot of the issue occurring, without the fix in this PR:
![image](https://user-images.githubusercontent.com/12543977/88521736-3c0e7280-cfed-11ea-98eb-ebfdc62068db.png)

A screenshot of the issue no longer occurring with the fix in this PR:
![image](https://user-images.githubusercontent.com/12543977/88521781-534d6000-cfed-11ea-87e6-8746dd42e5b9.png)
