### PR TITLE
Fix copy method not creating a version for the content model on error

### DIFF
--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -36,7 +36,7 @@ class UserFactory(factory.django.DjangoModelFactory):
         return manager.create_user(*args, **kwargs)
 
 
-class AbstractVersionFactory(factory.DjangoModelFactory):
+class AbstractVersionFactory(factory.django.DjangoModelFactory):
     object_id = factory.SelfAttribute("content.id")
     content_type = factory.LazyAttribute(
         lambda o: ContentType.objects.get_for_model(o.content)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,6 @@ flake8
 isort
 mock
 python-dateutil
-
 beautifulsoup4
+django-classy-tags<2.0.0
+django-sekizai<2.0.0


### PR DESCRIPTION
DB's are left in a corrupt state if the copy function is partially successful where Page, PageContent, Placeholder, Plugin models are created when a plugin copy error occurs.

The copy method should always run in a transaction to be sure that there is always a content object with a version!