### PR TITLE
Pin the djangocms-text-ckeditor package to the v4 branch for the test suite

### DIFF
--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -7,8 +7,9 @@ from django.contrib.sites.models import Site
 from cms import constants
 from cms.models import Page, PageContent, PageUrl, Placeholder, TreeNode
 
-import factory
 from djangocms_text_ckeditor.models import Text
+
+import factory
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from ..models import Version

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,6 @@ python-dateutil
 beautifulsoup4
 django-classy-tags<2.0.0
 django-sekizai<2.0.0
+
+# Get the lastest cms v4 compatible djangocms-text-ckeditor
+https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor


### PR DESCRIPTION
The djangocms-text-ckeditor package has been recently updated for cms3 to 4.0.x, we need to support the django-cms release 4.0.x branch not the djangocms-text-ckeditor 4.0.x release.