### PR TITLE
Changes added to display Content version number along with pk in compare view

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -788,7 +788,7 @@ class VersionAdmin(admin.ModelAdmin):
             "v1": v1,
             "v1_preview_url": v1_preview_url,
             "v1_description": format_html(
-                '{obj} (#{number}, {date})',
+                'Version #{number} ({date})',
                 obj=v1,
                 number=v1.number,
                 date=localize(localtime(v1.created)),
@@ -816,27 +816,13 @@ class VersionAdmin(admin.ModelAdmin):
                             **persist_params
                         ),
                         "v2_description": format_html(
-                            '{obj} (#{number}, {date})',
+                            'Version #{number} ({date})',
                             obj=v2,
                             number=v2.number,
                             date=localize(localtime(v2.created)),
                         ),
                     }
                 )
-                # context["v2"] = v2
-                # context["v2_preview_url"] = add_url_parameters(
-                #     reverse(
-                #         "admin:cms_placeholder_render_object_preview",
-                #         args=(v2.content_type_id, v2.object_id),
-                #     ),
-                #     **persist_params
-                # )
-                # context["v2_description"] = format_html(
-                #     '{obj} (#{number}, {date})',
-                #     obj=v2,
-                #     number=v2.number,
-                #     date=localize(localtime(v2.created)),
-                # ),
         return TemplateResponse(
             request, "djangocms_versioning/admin/compare.html", context
         )

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -13,7 +13,9 @@ from django.template.loader import render_to_string, select_template
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.encoding import force_text
+from django.utils.formats import localize
 from django.utils.html import format_html, format_html_join
+from django.utils.timezone import localtime
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import PageContent
@@ -785,8 +787,15 @@ class VersionAdmin(admin.ModelAdmin):
             "version_list": version_list,
             "v1": v1,
             "v1_preview_url": v1_preview_url,
+            "v1_description": format_html(
+                '{obj} (#{number}, {date})',
+                obj=v1,
+                number=v1.number,
+                date=localize(localtime(v1.created)),
+            ),
             "return_url": version_list_url(v1.content),
         }
+
         # Now check if version 2 has been specified and add to context
         # if yes
         if "compare_to" in request.GET:
@@ -796,14 +805,38 @@ class VersionAdmin(admin.ModelAdmin):
                     request, self.model._meta, request.GET["compare_to"]
                 )
             else:
-                context["v2"] = v2
-                context["v2_preview_url"] = add_url_parameters(
-                    reverse(
-                        "admin:cms_placeholder_render_object_preview",
-                        args=(v2.content_type_id, v2.object_id),
-                    ),
-                    **persist_params
+                context.update(
+                    {
+                        "v2": v2,
+                        "v2_preview_url": add_url_parameters(
+                            reverse(
+                                "admin:cms_placeholder_render_object_preview",
+                                args=(v2.content_type_id, v2.object_id),
+                            ),
+                            **persist_params
+                        ),
+                        "v2_description": format_html(
+                            '{obj} (#{number}, {date})',
+                            obj=v2,
+                            number=v2.number,
+                            date=localize(localtime(v2.created)),
+                        ),
+                    }
                 )
+                # context["v2"] = v2
+                # context["v2_preview_url"] = add_url_parameters(
+                #     reverse(
+                #         "admin:cms_placeholder_render_object_preview",
+                #         args=(v2.content_type_id, v2.object_id),
+                #     ),
+                #     **persist_params
+                # )
+                # context["v2_description"] = format_html(
+                #     '{obj} (#{number}, {date})',
+                #     obj=v2,
+                #     number=v2.number,
+                #     date=localize(localtime(v2.created)),
+                # ),
         return TemplateResponse(
             request, "djangocms_versioning/admin/compare.html", context
         )

--- a/djangocms_versioning/templates/djangocms_versioning/admin/compare.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/compare.html
@@ -3,7 +3,20 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Compare {{ v1 }} {{ v1.created }}{% if v2 %} to {{ v2 }} {{ v2.created }}{% endif %}</title>
+    <title>{% spaceless %}
+        {% if v1 and v2 %}
+        {% blocktrans with left=v1.description right=v1.description %}
+        Compare {{ left }} to {{ right }}
+        {% endblocktrans %}
+    {% elif v1 %}
+        {% blocktrans with left=v1.description %}
+        Compare {{ left }}
+        {% endblocktrans %}
+    {% elif right %}
+        {% blocktrans with right=v2.description %}
+        Compare {{ right }}
+        {% endblocktrans %}
+    {% endif %}{% endspaceless %}</title>
     <link rel="stylesheet" href="{% static_with_version "cms/css/cms.base.css" %}" />
     <link rel="stylesheet" href="{% static 'djangocms_versioning/css/versioning.css' %}">
 </head>
@@ -13,23 +26,23 @@
             "v2_url": "{{ v2_preview_url }}",
         {% endif %}
         {% if v2 %}
-        "v2_description": "{{ v2 }} {{ v2.created }}",
+            "v2_description": "{{ v2_description }}",
         {% endif %}
         "v1_url": "{{ v1_preview_url }}",
-        "v1_description": "{{ v1 }} {{ v1.created }}"
+        "v1_description": "{{ v1_description }}"
     }'>
         <div class="cms-toolbar">
             <div class="cms-versioning-controls">
                 <a class="cms-btn" href="{{ return_url }}">{% trans "Back" %}</a> &nbsp;
                 <span class="cms-versioning-title">
-                {% blocktrans  %}
-                    Comparing {{ v1 }} {{ v1.created }} with
+                {% blocktrans with left=v1_description %}
+                    Comparing {{ left }} with
                 {% endblocktrans %}
                 </span>
                 <select class="js-cms-versioning-version cms-select">
                     <option disabled {% if not request.GET.compare_to %} selected{% endif %}>{% trans "Pick a version to compare to" %}</option>
                     {% for version in version_list %}
-                        <option value="{{ version.pk }}" {% if v2 and v2.pk == version.pk %} selected{% endif %}>{{ version }} {{ version.created }}</option>
+                        <option value="{{ version.pk }}" {% if v2 and v2.pk == version.pk %} selected{% endif %}>{{ version }} (#{{ version.number }}, {{ version.created|date }})</option>
                     {% endfor %}
                 </select>
                 <div class="cms-tooblar-item cms-toolbar-item-buttons">

--- a/djangocms_versioning/templates/djangocms_versioning/admin/compare.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/compare.html
@@ -42,7 +42,7 @@
                 <select class="js-cms-versioning-version cms-select">
                     <option disabled {% if not request.GET.compare_to %} selected{% endif %}>{% trans "Pick a version to compare to" %}</option>
                     {% for version in version_list %}
-                        <option value="{{ version.pk }}" {% if v2 and v2.pk == version.pk %} selected{% endif %}>{{ version }} (#{{ version.number }}, {{ version.created|date }})</option>
+                        <option value="{{ version.pk }}" {% if v2 and v2.pk == version.pk %} selected{% endif %}>{% trans  'Version'%} #{{ version.number }}({{ version.created|date }})</option>
                     {% endfor %}
                 </select>
                 <div class="cms-tooblar-item cms-toolbar-item-buttons">

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -15,7 +15,7 @@ from django.test import RequestFactory
 from django.test.utils import ignore_warnings
 from django.urls import reverse
 from django.utils.formats import localize
-from django.utils.timezone import now, utc, localtime
+from django.utils.timezone import localtime, now, utc
 
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -14,7 +14,8 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
 from django.test.utils import ignore_warnings
 from django.urls import reverse
-from django.utils.timezone import now, utc
+from django.utils.formats import localize
+from django.utils.timezone import now, utc, localtime
 
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
@@ -1881,6 +1882,9 @@ class CompareViewTestCase(CMSTestCase):
         with self.login_user_context(user):
             response = self.client.get(url)
 
+        self.assertContains(response, "Version #{number} ({date})".format(
+            number=versions[0].number, date=localize(localtime(versions[0].created))))
+
         context = response.context
         self.assertIn("v1", context)
         self.assertEqual(context["v1"], versions[0])
@@ -1928,6 +1932,10 @@ class CompareViewTestCase(CMSTestCase):
 
         with self.login_user_context(user):
             response = self.client.get(url)
+
+        self.assertContains(response, "Comparing Version #{}".format(versions[0].number))
+        self.assertContains(response, "Version #{}".format(versions[0].number))
+        self.assertContains(response, "Version #{}".format(versions[1].number))
 
         context = response.context
         self.assertIn("v1", context)


### PR DESCRIPTION
 Changes added to display Content version number instead verion pk in compare view and also updated local timezone date display in compare
Current
![image](https://user-images.githubusercontent.com/18649264/102336286-e2e9b000-3f88-11eb-9b66-2d08a2784c91.png)

Updated
![image](https://user-images.githubusercontent.com/18649264/102335649-18da6480-3f88-11eb-9d1b-d4f65ca7c940.png)
