### PR TITLE
Feature: Copy method and Monkeypatch CMS Pagecontent Admin Extensions

### DIFF
--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -185,6 +185,18 @@ def copy_page_content(original_content):
         new_placeholders.append(new_placeholder)
     new_content.placeholders.add(*new_placeholders)
 
+    # If pagecontent has an associated title or page extension, also copy this!
+    for field in PageContent._meta.related_objects:
+        if hasattr(original_content, field.name):
+            extension = getattr(original_content, field.name)
+            extension_fields = {
+                field.name: getattr(extension, field.name)
+                for field in extension._meta.fields
+                if field.name not in (PageContent._meta.pk.name, "extended_object")
+            }
+            extension_fields["extended_object"] = new_content
+            field.related_model.objects.create(**extension_fields)
+
     return new_content
 
 

--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -60,7 +60,7 @@ def _save_model(self, request, obj, form, change):
     if not user_can_change_page(request.user, page=title.page):
         raise PermissionDenied()
 
-    super().save_model(request, obj, form, change)
+    super(TitleExtensionAdmin, self).save_model(request, obj, form, change)
 
 
 TitleExtensionAdmin.save_model = _save_model
@@ -89,7 +89,7 @@ def _add_view(self, request, form_url='', extra_context=None):
             return HttpResponseRedirect(change_url)
         except self.model.DoesNotExist:
             pass
-    return super().add_view(request, form_url, extra_context)
+    return super(TitleExtensionAdmin, self).add_view(request, form_url, extra_context)
 
 
 TitleExtensionAdmin.add_view = _add_view

--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -1,5 +1,12 @@
+from django.contrib.admin.options import csrf_protect_m
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+from cms.extensions.admin import TitleExtensionAdmin
 from cms.extensions.extension_pool import ExtensionPool
-from cms.models.titlemodels import PageContent
+from cms.models import PageContent
+from cms.utils.page_permissions import user_can_change_page
 
 
 def _copy_title_extensions(self, source_page, target_page, language, clone=False):
@@ -30,3 +37,59 @@ def _copy_title_extensions(self, source_page, target_page, language, clone=False
 
 
 ExtensionPool._copy_title_extensions = _copy_title_extensions
+
+
+def _save_model(self, request, obj, form, change):
+    """
+    djangocms-cms/extensions/admin.py, last changed in:
+    django-cms/django-cms@61e7756a79de0db9671417b44235bbf8866c3c9f
+
+    Ensure that the current page content object can be retrieved. A draft
+    object will return an empty set by default hence why we have to remove the
+    query manager here!
+    """
+    if not change and 'extended_object' in request.GET:
+        extended_object = PageContent._original_manager.get(
+            pk=request.GET['extended_object']
+        )
+        obj.extended_object = extended_object
+        title = extended_object
+    else:
+        title = obj.extended_object
+
+    if not user_can_change_page(request.user, page=title.page):
+        raise PermissionDenied()
+
+    super().save_model(request, obj, form, change)
+
+
+TitleExtensionAdmin.save_model = _save_model
+
+
+@csrf_protect_m
+def _add_view(self, request, form_url='', extra_context=None):
+    """
+    djangocms-cms/extensions/admin.py, last changed in:
+    django-cms/django-cms@61e7756a79de0db9671417b44235bbf8866c3c9f
+
+    Ensure that the current page content object can be retrieved. A draft
+    object will return an empty set by default hence why we have to remove the
+    query manager here!
+    """
+    extended_object_id = request.GET.get('extended_object', False)
+    if extended_object_id:
+        try:
+            title = PageContent._original_manager.get(pk=extended_object_id)
+            extension = self.model.objects.get(extended_object=title)
+            opts = self.model._meta
+            change_url = reverse('admin:%s_%s_change' %
+                                 (opts.app_label, opts.model_name),
+                                 args=(extension.pk,),
+                                 current_app=self.admin_site.name)
+            return HttpResponseRedirect(change_url)
+        except self.model.DoesNotExist:
+            pass
+    return super().add_view(request, form_url, extra_context)
+
+
+TitleExtensionAdmin.add_view = _add_view

--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -63,7 +63,7 @@ def _save_model(self, request, obj, form, change):
     super(TitleExtensionAdmin, self).save_model(request, obj, form, change)
 
 
-# TitleExtensionAdmin.save_model = _save_model
+TitleExtensionAdmin.save_model = _save_model
 
 
 @csrf_protect_m

--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -63,7 +63,7 @@ def _save_model(self, request, obj, form, change):
     super(TitleExtensionAdmin, self).save_model(request, obj, form, change)
 
 
-TitleExtensionAdmin.save_model = _save_model
+# TitleExtensionAdmin.save_model = _save_model
 
 
 @csrf_protect_m

--- a/djangocms_versioning/test_utils/extended_polls/admin.py
+++ b/djangocms_versioning/test_utils/extended_polls/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from cms.extensions import TitleExtensionAdmin
+
+from .models import PollExtension
+
+
+@admin.register(PollExtension)
+class PollExtensionAdmin(TitleExtensionAdmin):
+    pass

--- a/djangocms_versioning/test_utils/extended_polls/admin.py
+++ b/djangocms_versioning/test_utils/extended_polls/admin.py
@@ -2,9 +2,9 @@ from django.contrib import admin
 
 from cms.extensions import TitleExtensionAdmin
 
-from .models import PollExtension
+from .models import PollTitleExtension
 
 
-@admin.register(PollExtension)
+@admin.register(PollTitleExtension)
 class PollExtensionAdmin(TitleExtensionAdmin):
     pass

--- a/djangocms_versioning/test_utils/extended_polls/models.py
+++ b/djangocms_versioning/test_utils/extended_polls/models.py
@@ -5,7 +5,7 @@ from cms.extensions.extension_pool import extension_pool
 
 
 class PollTitleExtension(TitleExtension):
-    votes = models.CharField(max_length=255)
+    votes = models.IntegerField()
 
 
 extension_pool.register(PollTitleExtension)

--- a/djangocms_versioning/test_utils/extended_polls/models.py
+++ b/djangocms_versioning/test_utils/extended_polls/models.py
@@ -1,0 +1,11 @@
+from django.db import models
+
+from cms.extensions import TitleExtension
+from cms.extensions.extension_pool import extension_pool
+
+
+class PollTitleExtension(TitleExtension):
+    votes = models.CharField(max_length=255)
+
+
+extension_pool.register(PollTitleExtension)

--- a/djangocms_versioning/test_utils/extended_polls/templates/extended_polls/extended_polls.html
+++ b/djangocms_versioning/test_utils/extended_polls/templates/extended_polls/extended_polls.html
@@ -1,0 +1,1 @@
+{{ request.current_page.get_title_obj.ratingextensions.rating }}

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -13,6 +13,7 @@ import factory
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from ..models import Version
+from .extended_polls.models import PollTitleExtension
 from .blogpost.models import BlogContent, BlogPost
 from .polls.models import Answer, Poll, PollContent
 from .unversioned_editable_app.models import FancyPoll
@@ -241,3 +242,10 @@ class FancyPollFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = FancyPoll
+
+
+class PollTitleExtensionFactory(factory.django.DjangoModelFactory):
+    votes = FuzzyInteger(0, 100)
+
+    class Meta:
+        model = PollTitleExtension

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -14,6 +14,7 @@ from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from ..models import Version
 from .extended_polls.models import PollTitleExtension
+from .extensions.models import TestTitleExtension
 from .blogpost.models import BlogContent, BlogPost
 from .polls.models import Answer, Poll, PollContent
 from .unversioned_editable_app.models import FancyPoll
@@ -245,7 +246,15 @@ class FancyPollFactory(factory.django.DjangoModelFactory):
 
 
 class PollTitleExtensionFactory(factory.django.DjangoModelFactory):
+    extended_object = factory.SubFactory(PageContentFactory)
     votes = FuzzyInteger(0, 100)
 
     class Meta:
         model = PollTitleExtension
+
+
+class TestTitleExtensionFactory(factory.django.DjangoModelFactory):
+    extended_object = factory.SubFactory(PageContentFactory)
+
+    class Meta:
+        model = TestTitleExtension

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -9,7 +9,6 @@ from cms.models import Page, PageContent, PageUrl, Placeholder, TreeNode
 
 import factory
 from djangocms_text_ckeditor.models import Text
-
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from ..models import Version

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -7,15 +7,15 @@ from django.contrib.sites.models import Site
 from cms import constants
 from cms.models import Page, PageContent, PageUrl, Placeholder, TreeNode
 
+import factory
 from djangocms_text_ckeditor.models import Text
 
-import factory
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from ..models import Version
+from .blogpost.models import BlogContent, BlogPost
 from .extended_polls.models import PollTitleExtension
 from .extensions.models import TestTitleExtension
-from .blogpost.models import BlogContent, BlogPost
 from .polls.models import Answer, Poll, PollContent
 from .unversioned_editable_app.models import FancyPoll
 

--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,6 @@ INSTALL_REQUIREMENTS = [
     "django-fsm>=2.6,<2.7"
 ]
 
-TEST_REQUIREMENTS = [
-    "djangocms_helper",
-    "pillow<=5.4.1",  # Requirement for tests to be passing in python 3.4
-    "djangocms-text-ckeditor",
-    "factory-boy",
-    "freezegun",
-    "lxml<=4.3.5",
-    "bs4",
-]
-
-
 setup(
     name="djangocms-versioning",
     packages=find_packages(),
@@ -40,10 +29,4 @@ setup(
     author_email="info@divio.ch",
     url="http://github.com/divio/djangocms-versioning",
     license="BSD",
-    zip_safe=False,
-    tests_require=TEST_REQUIREMENTS,
-    dependency_links=[
-        "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
-        "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x",
-    ]
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -9,6 +9,7 @@ HELPER_SETTINGS = {
         "djangocms_versioning.test_utils.text",
         "djangocms_versioning.test_utils.people",
         "djangocms_versioning.test_utils.unversioned_editable_app",
+        "djangocms_versioning.test_utils.extended_polls",
     ],
     "MIGRATION_MODULES": {
         "auth": None,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,13 @@
-# test libraries
+beautifulsoup4
 coverage
-pyflakes>=2.1.1
+django-classy-tags<2.0.0
+django-sekizai<2.0.0
+djangocms_helper
 flake8
 isort
 mock
+pyflakes>=2.1.1
 python-dateutil
-beautifulsoup4
-django-classy-tags<2.0.0
-django-sekizai<2.0.0
 
-# Get the lastest cms v4 compatible djangocms-text-ckeditor
+# Unreleased dependancies
 https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -25,6 +25,7 @@ from cms.utils.urlutils import admin_reverse
 
 import pytz
 from bs4 import BeautifulSoup
+from freezegun import freeze_time
 
 import djangocms_versioning.helpers
 from djangocms_versioning import constants, helpers
@@ -46,7 +47,6 @@ from djangocms_versioning.test_utils.blogpost.cms_config import BlogpostCMSConfi
 from djangocms_versioning.test_utils.blogpost.models import BlogContent
 from djangocms_versioning.test_utils.polls.cms_config import PollsCMSConfig
 from djangocms_versioning.test_utils.polls.models import Answer, Poll, PollContent
-from freezegun import freeze_time
 
 
 class BaseStateTestCase(CMSTestCase):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,9 +6,10 @@ from cms.api import add_plugin
 from cms.models import Placeholder, UserSettings
 from cms.test_utils.testcases import CMSTestCase
 
+from freezegun import freeze_time
+
 from djangocms_versioning.models import Version
 from djangocms_versioning.test_utils import factories
-from freezegun import freeze_time
 
 
 class HandlersTestCase(CMSTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,8 @@ from django.utils.timezone import now
 
 from cms.test_utils.testcases import CMSTestCase
 
+from freezegun import freeze_time
+
 from djangocms_versioning.constants import DRAFT, PUBLISHED
 from djangocms_versioning.datastructures import VersionableItem, default_copy
 from djangocms_versioning.helpers import remove_published_where
@@ -12,7 +14,6 @@ from djangocms_versioning.models import Version, VersionQuerySet
 from djangocms_versioning.test_utils import factories
 from djangocms_versioning.test_utils.polls.cms_config import PollsCMSConfig
 from djangocms_versioning.test_utils.polls.models import Poll, PollContent
-from freezegun import freeze_time
 
 
 class CopyTestCase(CMSTestCase):

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -13,6 +13,8 @@ from cms.utils.urlutils import admin_reverse
 from djangocms_versioning.cms_config import copy_page_content
 from djangocms_versioning.compat import DJANGO_GTE_21
 from djangocms_versioning.plugin_rendering import VersionContentRenderer
+from djangocms_versioning.test_utils.extended_polls.admin import PollExtensionAdmin
+from djangocms_versioning.test_utils.extended_polls.models import PollTitleExtension
 from djangocms_versioning.test_utils.extensions.models import (
     TestPageExtension,
     TestTitleExtension,
@@ -27,8 +29,6 @@ from djangocms_versioning.test_utils.factories import (
     TestTitleExtensionFactory,
     TextPluginFactory,
 )
-from djangocms_versioning.test_utils.extended_polls.admin import PollExtensionAdmin
-from djangocms_versioning.test_utils.extended_polls.models import PollTitleExtension
 
 
 class MonkeypatchExtensionTestCase(CMSTestCase):

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -71,6 +71,8 @@ class MonkeypatchExtensionTestCase(CMSTestCase):
         new_pagecontent = copy_page_content(self.pagecontent)
 
         self.assertNotEqual(new_pagecontent.polltitleextension, poll_extension)
+        self.assertEqual(self.pagecontent.polltitleextension.pk, poll_extension.pk)
+        self.assertNotEqual(self.pagecontent.polltitleextension.pk, new_pagecontent.polltitleextension.pk)
         self.assertEqual(new_pagecontent.polltitleextension.votes, 5)
         self.assertEqual(PollTitleExtension._base_manager.count(), 2)
 
@@ -94,6 +96,10 @@ class MonkeypatchExtensionTestCase(CMSTestCase):
 
         new_pagecontent = copy_page_content(self.pagecontent)
 
+        self.assertNotEqual(new_pagecontent.polltitleextension, poll_extension)
+        self.assertEqual(self.pagecontent.polltitleextension.pk, poll_extension.pk)
+        self.assertNotEqual(new_pagecontent.testtitleextension, poll_extension)
+        self.assertEqual(self.pagecontent.testtitleextension.pk, poll_extension.pk)
         self.assertNotEqual(new_pagecontent.polltitleextension, poll_extension)
         self.assertNotEqual(new_pagecontent.testtitleextension, title_extension)
         self.assertEqual(new_pagecontent.polltitleextension.votes, 5)

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -1,6 +1,8 @@
 from unittest import skipIf
 
+from django.contrib import admin
 from django.contrib.sites.models import Site
+from django.test import RequestFactory
 
 from cms.extensions.extension_pool import ExtensionPool
 from cms.models import PageContent
@@ -25,6 +27,7 @@ from djangocms_versioning.test_utils.factories import (
     TextPluginFactory,
     PollTitleExtensionFactory,
 )
+from djangocms_versioning.test_utils.extended_polls.admin import PollExtensionAdmin
 from djangocms_versioning.test_utils.extended_polls.models import PollTitleExtension
 
 
@@ -96,6 +99,35 @@ class MonkeypatchExtensionTestCase(CMSTestCase):
         self.assertEqual(new_pagecontent.polltitleextension.votes, 5)
         self.assertEqual(PollTitleExtension._base_manager.count(), 2)
         self.assertEqual(TestTitleExtension._base_manager.count(), 2)
+
+    def test_title_extension_admin_monkey_patch_save(self):
+        """
+        When we have a page in x state, we must show the unfiltered queryset
+        TODO: Write this comment properly!!!!!
+        """
+        model_site = PollExtensionAdmin(admin_site=admin.AdminSite(), model=PollTitleExtension)
+        request = RequestFactory().get("/admin/extended_polls/pollextension/")
+        import pdb
+        pdb.set_trace()
+        poll_extension = PollTitleExtensionFactory(extended_object=self.pagecontent)
+        request.extended_object = poll_extension
+        request.user = self.get_superuser()
+        model_site.save_model(request, poll_extension, form=None, change=False)
+
+    def test_title_extension_admin_monkeypatch_add_view(self):
+        """
+
+        """
+        model_site = PollExtensionAdmin(admin_site=admin.AdminSite(), model=PollTitleExtension)
+        request = RequestFactory().get("/admin/extended_polls/pollextension/")
+        user = self.get_superuser()
+        with self.login_user_context(user):
+            response = model_site.add_view(request)
+            rendered_response = response.render()
+            import pdb
+            pdb.set_trace()
+
+
 
 
 class MonkeypatchTestCase(CMSTestCase):

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -22,6 +22,7 @@ from djangocms_versioning.test_utils.factories import (
     PageFactory,
     PageVersionFactory,
     PlaceholderFactory,
+    PollTitleExtensionFactory,
     PollVersionFactory,
     TestTitleExtensionFactory,
     TextPluginFactory,

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -108,7 +108,7 @@ class MonkeypatchExtensionTestCase(CMSTestCase):
         poll_extension = PollTitleExtensionFactory(extended_object=self.pagecontent)
         model_site = PollExtensionAdmin(admin_site=admin.AdminSite(), model=PollTitleExtension)
         test_url = admin_reverse("extended_polls_polltitleextension_change", args=(poll_extension.pk,))
-        test_url = test_url + f"?extended_object={self.version.content.pk}"
+        test_url = test_url + "?extended_object=%s" % self.version.content.pk
         request = RequestFactory().post(path=test_url)
         request.user = self.get_superuser()
 

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -25,7 +25,6 @@ from djangocms_versioning.test_utils.factories import (
     PollVersionFactory,
     TestTitleExtensionFactory,
     TextPluginFactory,
-    PollTitleExtensionFactory,
 )
 from djangocms_versioning.test_utils.extended_polls.admin import PollExtensionAdmin
 from djangocms_versioning.test_utils.extended_polls.models import PollTitleExtension

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -3,6 +3,7 @@ from django.utils.timezone import now
 from cms.test_utils.testcases import CMSTestCase
 
 from django_fsm import TransitionNotAllowed
+
 from freezegun import freeze_time
 
 from djangocms_versioning import constants

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -3,11 +3,11 @@ from django.utils.timezone import now
 from cms.test_utils.testcases import CMSTestCase
 
 from django_fsm import TransitionNotAllowed
+from freezegun import freeze_time
 
 from djangocms_versioning import constants
 from djangocms_versioning.models import StateTracking, Version
 from djangocms_versioning.test_utils import factories
-from freezegun import freeze_time
 
 
 class TestVersionState(CMSTestCase):

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -3,7 +3,6 @@ from django.utils.timezone import now
 from cms.test_utils.testcases import CMSTestCase
 
 from django_fsm import TransitionNotAllowed
-
 from freezegun import freeze_time
 
 from djangocms_versioning import constants


### PR DESCRIPTION
Copy method added to allow versioning, as well as monkey patch to override versioning query set filters when saving and adding extensions. 